### PR TITLE
feat: add prompt base class

### DIFF
--- a/lib/llm_gateway.rb
+++ b/lib/llm_gateway.rb
@@ -6,6 +6,7 @@ require_relative "llm_gateway/errors"
 require_relative "llm_gateway/fluent_mapper"
 require_relative "llm_gateway/base_client"
 require_relative "llm_gateway/client"
+require_relative "llm_gateway/prompt"
 
 # Load adapters - order matters for inheritance
 require_relative "llm_gateway/adapters/claude/client"

--- a/lib/llm_gateway/errors.rb
+++ b/lib/llm_gateway/errors.rb
@@ -2,7 +2,9 @@
 
 module LlmGateway
   module Errors
-    class BaseError < StandardError
+    class BaseError < StandardError; end
+
+    class ClientError < BaseError
       attr_reader :code
 
       def initialize(message = nil, code = nil)
@@ -11,20 +13,26 @@ module LlmGateway
       end
     end
 
-    class BadRequestError < BaseError; end
-    class AuthenticationError < BaseError; end
-    class PermissionDeniedError < BaseError; end
-    class NotFoundError < BaseError; end
-    class ConflictError < BaseError; end
-    class UnprocessableEntityError < BaseError; end
-    class RateLimitError < BaseError; end
-    class InternalServerError < BaseError; end
-    class APIStatusError < BaseError; end
-    class APITimeoutError < BaseError; end
-    class APIConnectionError < BaseError; end
-    class OverloadError < BaseError; end
-    class UnknownError < BaseError; end
+    class BadRequestError < ClientError; end
+    class AuthenticationError < ClientError; end
+    class PermissionDeniedError < ClientError; end
+    class NotFoundError < ClientError; end
+    class ConflictError < ClientError; end
+    class UnprocessableEntityError < ClientError; end
+    class RateLimitError < ClientError; end
+    class InternalServerError < ClientError; end
+    class APIStatusError < ClientError; end
+    class APITimeoutError < ClientError; end
+    class APIConnectionError < ClientError; end
+    class OverloadError < ClientError; end
+    class UnknownError < ClientError; end
     class PromptTooLong < BadRequestError; end
-    class UnsupportedModel < BaseError; end
+    class UnsupportedModel < ClientError; end
+
+    class PromptError < BaseError; end
+
+    class HallucinationError < PromptError; end
+    class UnknownModel < PromptError; end
+    class InvalidResponseGrammar < PromptError; end
   end
 end

--- a/lib/llm_gateway/prompt.rb
+++ b/lib/llm_gateway/prompt.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module LlmGateway
+  class Prompt
+    attr_reader :model
+
+    def self.before_execute(*methods, &block)
+      before_execute_callbacks.concat(methods)
+      before_execute_callbacks << block if block_given?
+    end
+
+    def self.after_execute(*methods, &block)
+      after_execute_callbacks.concat(methods)
+      after_execute_callbacks << block if block_given?
+    end
+
+    def self.before_execute_callbacks
+      @before_execute_callbacks ||= []
+    end
+
+    def self.after_execute_callbacks
+      @after_execute_callbacks ||= []
+    end
+
+    def self.inherited(subclass)
+      super
+      subclass.instance_variable_set(:@before_execute_callbacks, before_execute_callbacks.dup)
+      subclass.instance_variable_set(:@after_execute_callbacks, after_execute_callbacks.dup)
+    end
+
+    def initialize(model)
+      @model = model
+    end
+
+    def run
+      run_callbacks(:before_execute, prompt)
+
+      response = post
+
+      response_content = if respond_to?(:extract_response)
+        extract_response(response)
+      else
+        response[:choices][0][:content]
+      end
+
+      result = if respond_to?(:parse_response)
+        parse_response(response_content)
+      else
+        response_content
+      end
+
+      run_callbacks(:after_execute, response, response_content)
+
+      result
+    end
+
+    def post
+      LlmGateway::Client.chat(model, prompt, tools: tools, system: system_prompt)
+    end
+
+    def tools
+      nil
+    end
+
+    def self.find_tool(tool_name)
+      tools.find { |tool| tool.tool_name == tool_name }
+    end
+
+    def system_prompt
+      nil
+    end
+
+    private
+
+    def run_callbacks(callback_type, *args)
+      callbacks = self.class.send("#{callback_type}_callbacks")
+      callbacks.each do |callback|
+        if callback.is_a?(Proc)
+          instance_exec(*args, &callback)
+        elsif callback.is_a?(Symbol) || callback.is_a?(String)
+          send(callback, *args)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
this enables users to package prompts into reusable classes easily

i split the errors into errors where the client is the cause vs business logic in the prompt

as you want to catch them differently but i still want all the errors in the same namespace