### PR TITLE
feat: handle basic text document handling

### DIFF
--- a/lib/llm_gateway/adapters/open_ai/input_mapper.rb
+++ b/lib/llm_gateway/adapters/open_ai/input_mapper.rb
@@ -4,8 +4,85 @@ module LlmGateway
   module Adapters
     module OpenAi
       class InputMapper < LlmGateway::Adapters::Groq::InputMapper
+        map :messages do |_, value|
+          value.map do |msg|
+            if msg[:content].is_a?(Array)
+              results = []
+
+              # Check what content types we have
+              text_content = msg[:content].select { |c| c[:type] == "text" || c.is_a?(String) }
+              tool_uses = msg[:content].select { |c| c[:type] == "tool_use" }
+              tool_results = msg[:content].select { |c| c[:type] == "tool_result" }
+              files = msg[:content].select { |c| c[:type] == "file" }
+
+              # If we have text and/or files but no tools, combine them in one message
+              if (text_content.any? || files.any?) && tool_uses.empty? && tool_results.empty?
+                combined_content = []
+
+                # Add text content
+                text_content.each do |c|
+                  combined_content << {
+                    type: "text",
+                    text: c.is_a?(String) ? c : c[:text]
+                  }
+                end
+
+                # Add file content
+                files.each do |file|
+                  combined_content << {
+                    type: "file",
+                    file: {
+                      file_data: "data:application/pdf;base64,#{Base64.encode64(file[:data])}",
+                      filename: file[:name]
+                    }
+                  }
+                end
+
+                results << {
+                  role: msg[:role],
+                  content: combined_content
+                }
+              else
+                # Handle tool messages separately (they need to be separate messages)
+                if text_content.any?
+                  results << { role: msg[:role], content: text_content.map { |c| c.is_a?(String) ? c : c[:text] }.join }
+                end
+
+                # Handle tool_use messages
+                results << map_single(msg, with: :tool_usage) if tool_uses.any?
+
+                # Handle tool_result messages
+                tool_results.each do |content|
+                  results << map_single(content, with: :tool_result_message)
+                end
+
+                # Handle file content separately if there are tools
+                if files.any? && (tool_uses.any? || tool_results.any?)
+                  files.each do |file|
+                    results << {
+                      role: msg[:role],
+                      content: [ {
+                        type: "file",
+                        file: {
+                          file_data: "data:application/pdf;base64,#{Base64.encode64(file[:data])}",
+                          filename: file[:name]
+                        }
+                      } ]
+                    }
+                  end
+                end
+              end
+
+              # Return results or original message if no special content found
+              results.empty? ? msg : results
+            else
+              msg
+            end
+          end.flatten
+        end
+
         map :system do |_, value|
-          if value.empty?
+          if !value || value.empty?
             []
           else
             value.map do |msg|

--- a/test/fixtures/vcr_cassettes/integration/document_usage_test_rb/test_claude_document_usage.yml
+++ b/test/fixtures/vcr_cassettes/integration/document_usage_test_rb/test_claude_document_usage.yml
@@ -1,0 +1,85 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: https://api.anthropic.com/v1/messages
+      body:
+        encoding: UTF-8
+        string:
+          '{"model":"claude-sonnet-4-20250514","max_tokens":4096,"messages":[{"role":"user","content":[{"type":"text","text":"return
+          the content of the document exactly"},{"type":"document","source":{"data":"abc\n","type":"text","media_type":"text/plain"}}]}]}'
+      headers:
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+        User-Agent:
+          - Ruby
+        Host:
+          - api.anthropic.com
+        Anthropic-Version:
+          - "2023-06-01"
+        Content-Type:
+          - application/json
+        X-Api-Key:
+          - "<BEARER_TOKEN>"
+        Anthropic-Beta:
+          - code-execution-2025-05-22,files-api-2025-04-14
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Date:
+          - Thu, 07 Aug 2025 06:42:10 GMT
+        Content-Type:
+          - application/json
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Anthropic-Ratelimit-Input-Tokens-Limit:
+          - "450000"
+        Anthropic-Ratelimit-Input-Tokens-Remaining:
+          - "450000"
+        Anthropic-Ratelimit-Input-Tokens-Reset:
+          - "2025-08-07T06:42:10Z"
+        Anthropic-Ratelimit-Output-Tokens-Limit:
+          - "90000"
+        Anthropic-Ratelimit-Output-Tokens-Remaining:
+          - "90000"
+        Anthropic-Ratelimit-Output-Tokens-Reset:
+          - "2025-08-07T06:42:10Z"
+        Anthropic-Ratelimit-Requests-Limit:
+          - "1000"
+        Anthropic-Ratelimit-Requests-Remaining:
+          - "999"
+        Anthropic-Ratelimit-Requests-Reset:
+          - "2025-08-07T06:42:09Z"
+        Anthropic-Ratelimit-Tokens-Limit:
+          - "540000"
+        Anthropic-Ratelimit-Tokens-Remaining:
+          - "540000"
+        Anthropic-Ratelimit-Tokens-Reset:
+          - "2025-08-07T06:42:10Z"
+        Request-Id:
+          - req_011CRstpEw8a5ka2WWn4tU5G
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        Anthropic-Organization-Id:
+          - 0fcc9bdc-70ee-4701-a64f-cdc9e356dfa8
+        Via:
+          - 1.1 google
+        Cf-Cache-Status:
+          - DYNAMIC
+        X-Robots-Tag:
+          - none
+        Server:
+          - cloudflare
+        Cf-Ray:
+          - 96b4cad94a6840b9-SIN
+      body:
+        encoding: ASCII-8BIT
+        string: '{"id":"msg_01MthAWCPBxCqc6pvfFKnoAf","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[{"type":"text","text":"abc"}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":53,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":4,"service_tier":"standard"}}'
+    recorded_at: Thu, 07 Aug 2025 06:42:10 GMT
+recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/integration/document_usage_test_rb/test_openai_document_usage.yml
+++ b/test/fixtures/vcr_cassettes/integration/document_usage_test_rb/test_openai_document_usage.yml
@@ -1,0 +1,85 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"o4-mini","messages":[{"role":"user","content":[{"type":"text","text":"return
+        the content of the document exactly"},{"type":"file","file":{"file_data":"data:application/pdf;base64,YWJjCg==\n","filename":"small.txt"}}]}],"max_completion_tokens":4096}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.openai.com
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Aug 2025 06:36:55 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - user-ayzusypxu6roh2akxcbajqo9
+      Openai-Processing-Ms:
+      - '7706'
+      Openai-Project:
+      - proj_nmULvLHfn5yjMz2KqRbQcEQl
+      Openai-Version:
+      - '2020-10-01'
+      X-Envoy-Upstream-Service-Time:
+      - '7805'
+      X-Ratelimit-Limit-Requests:
+      - '500'
+      X-Ratelimit-Limit-Tokens:
+      - '200000'
+      X-Ratelimit-Remaining-Requests:
+      - '499'
+      X-Ratelimit-Remaining-Tokens:
+      - '199222'
+      X-Ratelimit-Reset-Requests:
+      - 120ms
+      X-Ratelimit-Reset-Tokens:
+      - 233ms
+      X-Request-Id:
+      - req_215dc2350fd04bf58517c192063d09e5
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=1ca8POs.S7U9zmcPY98jA2Aw9my2dADbAgAcT4GmLaI-1754548615-1.0.1.1-lwmE7t_891ZsnOL6SVSDA895C_L19dsnVjc59dqGCO0mevWkZPj0Rcug20W3uVuTqWwEczWG6huICDfnsOyoVWeZtAn01QCdY84YIv5tDGQ;
+        path=/; expires=Thu, 07-Aug-25 07:06:55 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=qSa2fqzTUcnzvYApyf8Obs8IORi2oMRfI5lygQzhxdY-1754548615585-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 96b4c2fbbe06cdea-SIN
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1DMW9YMUs5ekxqVUFVQ1ZJUDJiU2djY2lMdTFPeCIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc1NDU0ODYwNywKICAibW9kZWwiOiAibzQtbWluaS0yMDI1LTA0LTE2IiwKICAiY2hvaWNlcyI6IFsKICAgIHsKICAgICAgImluZGV4IjogMCwKICAgICAgIm1lc3NhZ2UiOiB7CiAgICAgICAgInJvbGUiOiAiYXNzaXN0YW50IiwKICAgICAgICAiY29udGVudCI6ICJJ4oCZbSBoYXBweSB0byBoZWxw4oCUYnV0IEkgZG9u4oCZdCBhY3R1YWxseSBzZWUgdGhlIGNvbnRlbnRzIG9mIOKAnGFiY+KAnSBpbiBvdXIgY2hhdCBoaXN0b3J5LiBDb3VsZCB5b3UgcGxlYXNlIHVwbG9hZCBvciBwYXN0ZSB0aGUgZG9jdW1lbnQgaXRzZWxmIHNvIEkgY2FuIHJldHVybiBpdHMgZnVsbCwgdmVyYmF0aW0gdGV4dD8iLAogICAgICAgICJyZWZ1c2FsIjogbnVsbCwKICAgICAgICAiYW5ub3RhdGlvbnMiOiBbXQogICAgICB9LAogICAgICAiZmluaXNoX3JlYXNvbiI6ICJzdG9wIgogICAgfQogIF0sCiAgInVzYWdlIjogewogICAgInByb21wdF90b2tlbnMiOiAyMTgsCiAgICAiY29tcGxldGlvbl90b2tlbnMiOiA4MjgsCiAgICAidG90YWxfdG9rZW5zIjogMTA0NiwKICAgICJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJjYWNoZWRfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0sCiAgICAiY29tcGxldGlvbl90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgInJlYXNvbmluZ190b2tlbnMiOiA3NjgsCiAgICAgICJhdWRpb190b2tlbnMiOiAwLAogICAgICAiYWNjZXB0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAicmVqZWN0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwCiAgICB9CiAgfSwKICAic2VydmljZV90aWVyIjogImRlZmF1bHQiLAogICJzeXN0ZW1fZmluZ2VycHJpbnQiOiBudWxsCn0K
+  recorded_at: Thu, 07 Aug 2025 06:36:55 GMT
+recorded_with: VCR 6.3.1

--- a/test/integration/clients/llm/mappers/input_document_mapper_test.rb
+++ b/test/integration/clients/llm/mappers/input_document_mapper_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class InputDocumentMapperTest < Test
+  test "claude input document mapping" do
+    input = { messages: [ { role: "user", content: [ { type: "text", text: "return the content of the document exactly" }, { type: "file", data: "abc\n", media_type: "text/plain", name: "small.txt"  } ] } ] }
+    output = [ { role: "user", content: [ { type: "text", text: "return the content of the document exactly" }, { type: "document", source: { media_type: "text/plain", type: "text", data: "abc\n" } } ] } ]
+    result = LlmGateway::Adapters::Claude::InputMapper.map(input)
+    assert_equal output, result[:messages]
+    end
+
+  test "openai input document mapping" do
+    input = { messages: [ { role: "user", content: [ { type: "text", text: "return the content of the document exactly" }, { type: "file", data: "abc\n", media_type: "text/plain", name: "small.txt" } ] } ] }
+    output = [ { role: "user", content: [ { type: "text", text: "return the content of the document exactly" }, { type: "file", file: { filename: "small.txt", file_data: "data:application/pdf;base64,#{Base64.encode64("abc\n")}" } } ] } ]
+    result = LlmGateway::Adapters::OpenAi::InputMapper.map(input)
+
+    assert_equal output, result[:messages]
+    end
+end
+
+
+
+
+# message = [ { role: "user", content: [ { type: "text", text: "return the content of the document exactly" }, { type: "document", source: { media_type: "text/plain", type: "text", data: "abc\n" } } ] } ]

--- a/test/integration/document_usage_test.rb
+++ b/test/integration/document_usage_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DocumentUsageTest < Test
+  test "claude document usage" do
+    message = [ { role: "user", content: [ { type: "text", text: "return the content of the document exactly" }, { type: "file", data: "abc\n", media_type: "text/plain", name: "small.txt"  } ] } ]
+    VCR.use_cassette(vcr_cassette_name) do
+      result = LlmGateway::Client.chat(
+        "claude-sonnet-4-20250514",
+        message,
+      )
+      assert("abc", result[:choices][0][:content][0][:text])
+    end
+  end
+
+  test "openai document usage" do
+    # plain text apparently uses pdg mime type
+    message = [ { role: "user", content: [ { type: "text", text: "return the content of the document exactly" }, { type: "file", data: "abc\n", media_type: "text/plain", name: "small.txt"  } ] } ]
+    VCR.use_cassette(vcr_cassette_name) do
+      result = LlmGateway::Client.chat(
+        "o4-mini",
+        message,
+      )
+      assert("abc", result[:choices][0][:content][0][:text])
+    end
+  end
+end


### PR DESCRIPTION
claude accepts plain text but does not want it to be encoded as base64. opena ai accepts plain text but wants it to be base64 and be pdf type when system message is null add better handling ( found this because test does not pass system at all)