### PR TITLE
refactor: message mapper to become bidirectional mapper

### DIFF
--- a/lib/llm_gateway.rb
+++ b/lib/llm_gateway.rb
@@ -21,4 +21,8 @@ require_relative "llm_gateway/adapters/groq/output_mapper"
 
 module LlmGateway
   class Error < StandardError; end
+
+  # Direction constants for message mappers
+  DIRECTION_IN = :in
+  DIRECTION_OUT = :out
 end

--- a/lib/llm_gateway/adapters/claude/bidirectional_message_mapper.rb
+++ b/lib/llm_gateway/adapters/claude/bidirectional_message_mapper.rb
@@ -3,8 +3,14 @@
 module LlmGateway
   module Adapters
     module Claude
-      class MessageMapper
-        def self.map_content(content)
+      class BidirectionalMessageMapper
+        attr_reader :direction
+
+        def initialize(direction)
+          @direction = direction
+        end
+
+        def map_content(content)
           # Convert string content to text format
           content = { type: "text", text: content } unless content.is_a?(Hash)
 
@@ -26,14 +32,14 @@ module LlmGateway
 
         private
 
-        def self.map_text_content(content)
+        def map_text_content(content)
           {
             type: "text",
             text: content[:text]
           }
         end
 
-        def self.map_file_content(content)
+        def map_file_content(content)
           {
             type: "document",
             source: {
@@ -44,7 +50,7 @@ module LlmGateway
           }
         end
 
-        def self.map_image_content(content)
+        def map_image_content(content)
           {
             type: "image",
             source: {
@@ -55,7 +61,7 @@ module LlmGateway
           }
         end
 
-        def self.map_tool_use_content(content)
+        def map_tool_use_content(content)
           {
             type: "tool_use",
             id: content[:id],
@@ -64,7 +70,7 @@ module LlmGateway
           }
         end
 
-        def self.map_tool_result_content(content)
+        def map_tool_result_content(content)
           {
             type: "tool_result",
             tool_use_id: content[:tool_use_id],

--- a/lib/llm_gateway/adapters/claude/input_mapper.rb
+++ b/lib/llm_gateway/adapters/claude/input_mapper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "message_mapper"
+require_relative "bidirectional_message_mapper"
 
 module LlmGateway
   module Adapters
@@ -20,15 +20,17 @@ module LlmGateway
         def self.map_messages(messages)
           return messages unless messages
 
+          message_mapper = BidirectionalMessageMapper.new(LlmGateway::DIRECTION_IN)
+
           messages.map do |msg|
             msg = msg.merge(role: "user") if msg[:role] == "developer"
 
             content = if msg[:content].is_a?(Array)
                 msg[:content].map do |content|
-                  MessageMapper.map_content(content)
+                  message_mapper.map_content(content)
                 end
             else
-              [ MessageMapper.map_content(msg[:content]) ]
+              [ message_mapper.map_content(msg[:content]) ]
             end
 
             {

--- a/lib/llm_gateway/adapters/claude/output_mapper.rb
+++ b/lib/llm_gateway/adapters/claude/output_mapper.rb
@@ -26,10 +26,20 @@ module LlmGateway
         private
 
         def self.map_choices(data)
+          message_mapper = BidirectionalMessageMapper.new(LlmGateway::DIRECTION_OUT)
+
+          content = if data[:content].is_a?(Array)
+              data[:content].map do |content|
+                message_mapper.map_content(content)
+              end
+          else
+            data[:content] ? [ message_mapper.map_content(data[:content]) ] : []
+          end
+
           # Claude returns content directly at root level, not in a choices array
           # We need to construct the choices array from the full response data
           [ {
-            content: data[:content] || [], # Use content directly from Claude response
+            content: content, # Use content directly from Claude response
             finish_reason: data[:stop_reason],
             role: "assistant"
           } ]

--- a/lib/llm_gateway/adapters/groq/bidirectional_message_mapper.rb
+++ b/lib/llm_gateway/adapters/groq/bidirectional_message_mapper.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require_relative "../open_ai/message_mapper"
+require_relative "../open_ai/bidirectional_message_mapper"
 
 module LlmGateway
   module Adapters
     module Groq
-      class MessageMapper < OpenAi::MessageMapper
+      class BidirectionalMessageMapper < OpenAi::BidirectionalMessageMapper
         private
 
-        def self.map_file_content(content)
+        def map_file_content(content)
           # Groq doesn't support files, return as text
           content[:text] || "[File: #{content[:name]}]"
         end

--- a/lib/llm_gateway/adapters/groq/input_mapper.rb
+++ b/lib/llm_gateway/adapters/groq/input_mapper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "message_mapper"
+require_relative "bidirectional_message_mapper"
 require_relative "../open_ai/input_mapper"
 
 module LlmGateway

--- a/lib/llm_gateway/adapters/open_ai/input_mapper.rb
+++ b/lib/llm_gateway/adapters/open_ai/input_mapper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "base64"
-require_relative "message_mapper"
+require_relative "bidirectional_message_mapper"
 
 module LlmGateway
   module Adapters
@@ -25,16 +25,18 @@ module LlmGateway
         def self.map_messages(messages)
           return messages unless messages
 
+          message_mapper = BidirectionalMessageMapper.new(LlmGateway::DIRECTION_IN)
+
           # First map messages like Claude
           mapped_messages = messages.map do |msg|
             msg = msg.merge(role: "user") if msg[:role] == "developer"
 
             content = if msg[:content].is_a?(Array)
                 msg[:content].map do |content|
-                  MessageMapper.map_content(content)
+                  message_mapper.map_content(content)
                 end
             else
-              [ MessageMapper.map_content(msg[:content]) ]
+              [ message_mapper.map_content(msg[:content]) ]
             end
 
             {


### PR DESCRIPTION
this will now allow us to build the unidirectional mapper which consumers of the api will use

bidirectional mapper also ensures that we colocate the mapping of messages in both directions