### PR TITLE
test: make tests less brittle when regenerating vcr

### DIFF
--- a/test/integration/document_usage_test.rb
+++ b/test/integration/document_usage_test.rb
@@ -17,7 +17,17 @@ class DocumentUsageTest < Test
   test "cluade upload file" do
     VCR.use_cassette(vcr_cassette_name) do
       result = LlmGateway::Client.upload_file("anthropic", filename: "test.txt", content: "Hello, world!", mime_type: "text/plain")
-      assert_equal(result, { id: "file_011CRub6FQG7ympTxXw81mic", size_bytes: 13, created_at: "2025-08-08T04:10:55.298000Z", filename: "test.txt", mime_type: "application/octet-stream", downloadable: false, expires_at: nil, purpose: "user_data" })
+      expected = {
+        id: ->(value, path) { assert_match(/\Afile[-_]/, value, path) },
+        created_at: ->(value, path) { assert(Time.iso8601(value), path) },
+        size_bytes: 13,
+        filename: "test.txt",
+        downloadable: false,
+        purpose: "user_data",
+        mime_type: "application/octet-stream",
+        expires_at: nil
+      }
+      assert_llm_response(expected, result)
     end
   end
 
@@ -32,7 +42,17 @@ class DocumentUsageTest < Test
   test "openai upload file" do
     VCR.use_cassette(vcr_cassette_name) do
       result = LlmGateway::Client.upload_file("openai", filename: "test.txt", content: "Hello, world!", mime_type: "text/plain")
-      assert_equal(result, { id: "file-Kb6X7f8YDffu7FG1NcaPVu", size_bytes: 13, created_at: "2025-08-08T06:03:16.000000Z", filename: "test.txt", mime_type: nil, downloadable: false, expires_at: nil, purpose: "user_data" })
+      expected = {
+        id: ->(value, path) { assert_match(/\Afile[-_]/, value, path) },
+        created_at: ->(value, path) { assert(Time.iso8601(value), path) },
+        size_bytes: 13,
+        filename: "test.txt",
+        downloadable: false,
+        purpose: "user_data",
+        mime_type: nil,
+        expires_at: nil
+      }
+      assert_llm_response(expected, result)
     end
   end
 

--- a/test/integration/gateway_test.rb
+++ b/test/integration/gateway_test.rb
@@ -72,12 +72,22 @@ class GatewayTest < Test
         system: "Talk like a pirate"
       )
       expected = {
+        id: ->(value, path) { assert_match(/\Amsg_/, value, path) },
+        model: "claude-sonnet-4-20250514",
+        usage: {
+          input_tokens: 404,
+          output_tokens: ->(value, path) { assert_operator value, :>, 0, path },
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          cache_creation: { ephemeral_5m_input_tokens: 0, ephemeral_1h_input_tokens: 0 },
+          service_tier: "standard"
+        },
         choices: [
           {
             content: [
               {
                 type: "tool_use",
-                id: "toolu_013LYTnUowbQcHw7i1JYj8ek",
+                id: ->(value, path) { assert_match(/\Atoolu_/, value, path) },
                 name: "get_weather",
                 input: { location: "Singapore" }
               }
@@ -85,12 +95,9 @@ class GatewayTest < Test
             finish_reason: "tool_use",
             role: "assistant"
           }
-        ],
-        usage: { input_tokens: 404, cache_creation_input_tokens: 0, cache_read_input_tokens: 0, cache_creation: { ephemeral_5m_input_tokens: 0, ephemeral_1h_input_tokens: 0 }, output_tokens: 53, service_tier: "standard" },
-        model: "claude-sonnet-4-20250514",
-        id: "msg_01AUZsdM9sPbZm6WjBy9CXNi"
+        ]
       }
-      assert_equal(expected, result)
+      assert_llm_response(expected, result)
     end
   end
 
@@ -103,22 +110,30 @@ class GatewayTest < Test
         system: "Talk like a pirate"
       )
       expected = {
+        id: ->(value, path) { assert_match(/\Achatcmpl-/, value, path) },
+        model: "llama-3.3-70b-versatile",
+        usage: {
+          prompt_tokens: ->(value, path) { assert_operator value, :>, 0, path },
+          completion_tokens: ->(value, path) { assert_operator value, :>, 0, path },
+          total_tokens: ->(value, path) { assert_operator value, :>, 0, path },
+          queue_time: ->(value, path) { assert_kind_of Numeric, value, path },
+          prompt_time: ->(value, path) { assert_kind_of Numeric, value, path },
+          completion_time: ->(value, path) { assert_kind_of Numeric, value, path },
+          total_time: ->(value, path) { assert_kind_of Numeric, value, path }
+        },
         choices: [
           {
             role: "assistant",
             content: [
               {
                 type: "text",
-                text: "Get the weather in Singapore right now please matey"
+                text: ->(value, path) { assert_match(/singapore|weather/i, value, path) }
               }
             ]
           }
-        ],
-        usage: { queue_time: 0.045523684, prompt_tokens: 237, prompt_time: 0.032411516, completion_tokens: 11, completion_time: 0.039058012, total_tokens: 248, total_time: 0.071469528 },
-        model: "llama-3.3-70b-versatile",
-        id: "chatcmpl-daedc002-441d-4d79-a91d-1e61de39dfee"
+        ]
       }
-      assert_equal(expected, result)
+      assert_llm_response(expected, result)
     end
   end
 
@@ -131,24 +146,35 @@ class GatewayTest < Test
         system: "Talk like a pirate"
       )
       expected = {
+        id: ->(value, path) { assert_match(/\Achatcmpl-/, value, path) },
+        model: "o4-mini-2025-04-16",
+        usage: {
+          prompt_tokens: 71,
+          completion_tokens: ->(value, path) { assert_operator value, :>, 0, path },
+          total_tokens: ->(value, path) { assert_operator value, :>, 0, path },
+          prompt_tokens_details: { cached_tokens: 0, audio_tokens: 0 },
+          completion_tokens_details: {
+            reasoning_tokens: ->(value, path) { assert_kind_of Integer, value, path },
+            audio_tokens: 0,
+            accepted_prediction_tokens: 0,
+            rejected_prediction_tokens: 0
+          }
+        },
         choices: [
           {
             role: "assistant",
             content: [
               {
-                id: "call_8DnGFFRKGF8xYpaT7AZqFKHc",
+                id: ->(value, path) { assert_match(/\Acall_/, value, path) },
                 type: "tool_use",
                 name: "get_weather",
                 input: { location: "Singapore" }
               }
             ]
           }
-        ],
-        usage: { prompt_tokens: 71, completion_tokens: 215, total_tokens: 286, prompt_tokens_details: { cached_tokens: 0, audio_tokens: 0 }, completion_tokens_details: { reasoning_tokens: 192, audio_tokens: 0, accepted_prediction_tokens: 0, rejected_prediction_tokens: 0 } },
-        id: "chatcmpl-C5Zba9y9OG70FEV8Ber4LIrtxlXdd",
-        model: "o4-mini-2025-04-16"
+        ]
       }
-      assert_equal(expected, result)
+      assert_llm_response(expected, result)
     end
   end
 
@@ -160,22 +186,30 @@ class GatewayTest < Test
         system: "Talk like a pirate"
       )
       expected = {
+        id: ->(value, path) { assert_match(/\Achatcmpl-/, value, path) },
+        model: "llama-3.3-70b-versatile",
+        usage: {
+          prompt_tokens: ->(value, path) { assert_operator value, :>, 0, path },
+          completion_tokens: ->(value, path) { assert_operator value, :>, 0, path },
+          total_tokens: ->(value, path) { assert_operator value, :>, 0, path },
+          queue_time: ->(value, path) { assert_kind_of Numeric, value, path },
+          prompt_time: ->(value, path) { assert_kind_of Numeric, value, path },
+          completion_time: ->(value, path) { assert_kind_of Numeric, value, path },
+          total_time: ->(value, path) { assert_kind_of Numeric, value, path }
+        },
         choices: [
           {
             role: "assistant",
             content: [
               {
                 type: "text",
-                text: "The weather in Singapore is usually hot and very humid"
+                text: ->(value, path) { assert_match(/singapore|weather|hot|humid/i, value, path) }
               }
             ]
           }
-        ],
-        usage: { queue_time: 0.044468705, prompt_tokens: 55, prompt_time: 0.011753645, completion_tokens: 11, completion_time: 0.03198708, total_tokens: 66, total_time: 0.043740725 },
-        id: "chatcmpl-5de6e422-9002-437c-b118-5a378bb9e364",
-        model: "llama-3.3-70b-versatile"
+        ]
       }
-      assert_equal(expected, result)
+      assert_llm_response(expected, result)
     end
   end
 
@@ -187,22 +221,33 @@ class GatewayTest < Test
         system: "Talk like a pirate"
       )
       expected = {
+        id: ->(value, path) { assert_match(/\Achatcmpl-/, value, path) },
+        model: "o4-mini-2025-04-16",
+        usage: {
+          prompt_tokens: 29,
+          completion_tokens: ->(value, path) { assert_operator value, :>, 0, path },
+          total_tokens: ->(value, path) { assert_operator value, :>, 0, path },
+          prompt_tokens_details: { cached_tokens: 0, audio_tokens: 0 },
+          completion_tokens_details: {
+            reasoning_tokens: ->(value, path) { assert_kind_of Integer, value, path },
+            audio_tokens: 0,
+            accepted_prediction_tokens: 0,
+            rejected_prediction_tokens: 0
+          }
+        },
         choices: [
           {
             role: "assistant",
             content: [
               {
                 type: "text",
-                text: "arr matey it be sunny and humid in singapore today"
+                text: ->(value, path) { assert_match(/singapore/i, value, path) }
               }
             ]
           }
-        ],
-        usage: { prompt_tokens: 29, completion_tokens: 413, total_tokens: 442, prompt_tokens_details: { cached_tokens: 0, audio_tokens: 0 }, completion_tokens_details: { reasoning_tokens: 384, audio_tokens: 0, accepted_prediction_tokens: 0, rejected_prediction_tokens: 0 } },
-        id: "chatcmpl-C5Zbqa3BeMwr7OUtARXvoUfRrrngZ",
-        model: "o4-mini-2025-04-16"
+        ]
       }
-      assert_equal(expected, result)
+      assert_llm_response(expected, result)
     end
   end
 
@@ -210,12 +255,34 @@ class GatewayTest < Test
     VCR.use_cassette(vcr_cassette_name) do
       result = call_gateway_with_tool_response("claude-sonnet-4-20250514")
       expected = {
-        choices: [ { content: [ { type: "text", text: "Arrr matey Singapore be mighty cold at negative fifteen degrees" } ], finish_reason: "end_turn", role: "assistant" } ],
-        usage: { input_tokens: 475, cache_creation_input_tokens: 0, cache_read_input_tokens: 0, cache_creation: { ephemeral_5m_input_tokens: 0, ephemeral_1h_input_tokens: 0 }, output_tokens: 16, service_tier: "standard" },
+        id: ->(value, path) { assert_match(/\Amsg_/, value, path) },
         model: "claude-sonnet-4-20250514",
-        id: "msg_01SJa9Udt1peeTMZxmZoV9t5"
+        usage: {
+          input_tokens: 475,
+          output_tokens: ->(value, path) { assert_operator value, :>, 0, path },
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          cache_creation: { ephemeral_5m_input_tokens: 0, ephemeral_1h_input_tokens: 0 },
+          service_tier: "standard"
+        },
+        choices: [
+          {
+            role: "assistant",
+            finish_reason: "end_turn",
+            content: [
+              {
+                type: "text",
+                text: ->(value, path) {
+                  assert_match(/singapore/i, value, path)
+                  assert_match(/fifteen/i, value, path)
+                  assert_match(/ahoy|arr|matey/i, value, path)
+                }
+              }
+            ]
+          }
+        ]
       }
-      assert_equal(expected, result)
+      assert_llm_response(expected, result)
     end
   end
 
@@ -239,22 +306,36 @@ class GatewayTest < Test
     VCR.use_cassette(vcr_cassette_name) do
       result = call_gateway_with_tool_response("o4-mini")
       expected = {
+        id: ->(value, path) { assert_match(/\Achatcmpl-/, value, path) },
+        model: "o4-mini-2025-04-16",
+        usage: {
+          prompt_tokens: ->(value, path) { assert_kind_of Integer, value, path },
+          completion_tokens: ->(value, path) { assert_operator value, :>, 0, path },
+          total_tokens: ->(value, path) { assert_operator value, :>, 0, path },
+          prompt_tokens_details: { cached_tokens: 0, audio_tokens: 0 },
+          completion_tokens_details: {
+            reasoning_tokens: ->(value, path) { assert_kind_of Integer, value, path },
+            audio_tokens: 0,
+            accepted_prediction_tokens: 0,
+            rejected_prediction_tokens: 0
+          }
+        },
         choices: [
           {
             role: "assistant",
             content: [
               {
                 type: "text",
-                text: "Arrr it be minus fifteen degrees in Singapore today matey!"
+                text: ->(value, path) {
+                  assert_match(/singapore/i, value, path)
+                  assert_match(/fifteen/i, value, path)
+                }
               }
             ]
           }
-        ],
-        usage: { prompt_tokens: 103, completion_tokens: 25, total_tokens: 128, prompt_tokens_details: { cached_tokens: 0, audio_tokens: 0 }, completion_tokens_details: { reasoning_tokens: 0, audio_tokens: 0, accepted_prediction_tokens: 0, rejected_prediction_tokens: 0 } },
-        id: "chatcmpl-C5Zw2oSyhLzRaNHUdtvdbMtLqooIH",
-        model: "o4-mini-2025-04-16"
+        ]
       }
-      assert_equal(expected, result)
+      assert_llm_response(expected, result)
     end
   end
 end


### PR DESCRIPTION
we walk the result hash to make sure we assert all the values if values are dynamic over temporal range then we use lambda so that when we regenerate it doesnt require lots of fixing