### PR TITLE
cross provider handoff support

### DIFF
--- a/lib/llm_gateway/adapters/adapter.rb
+++ b/lib/llm_gateway/adapters/adapter.rb
@@ -6,11 +6,12 @@ require_relative "structs"
 module LlmGateway
   module Adapters
     class Adapter
-      attr_reader :client, :input_mapper, :output_mapper, :file_output_mapper, :option_mapper, :client_method, :stream_mapper
+      attr_reader :client, :input_mapper, :input_sanitizer, :output_mapper, :file_output_mapper, :option_mapper, :client_method, :stream_mapper
 
-      def initialize(client, input_mapper:, output_mapper:, file_output_mapper: nil, stream_mapper: nil, option_mapper: OptionMapper, client_method: :chat)
+      def initialize(client, input_mapper:, input_sanitizer: nil, output_mapper:, file_output_mapper: nil, stream_mapper: nil, option_mapper: OptionMapper, client_method: :chat)
         @client = client
         @input_mapper = input_mapper
+        @input_sanitizer = input_sanitizer
         @output_mapper = output_mapper
         @file_output_mapper = file_output_mapper
         @option_mapper = option_mapper
@@ -20,7 +21,7 @@ module LlmGateway
 
       def chat(message, tools: nil, system: nil, **options)
         normalized_input = input_mapper.map({
-          messages: normalize_messages(message),
+          messages: sanitize_messages(normalize_messages(message)),
           tools: tools,
           system: normalize_system(system)
         })
@@ -40,7 +41,7 @@ module LlmGateway
         raise LlmGateway::Errors::MissingMapperForProvider, "No stream_mapper configured" unless stream_mapper
 
         normalized_input = input_mapper.map({
-          messages: normalize_messages(message),
+          messages: sanitize_messages(normalize_messages(message)),
           tools: tools,
           system: normalize_system(system)
         })
@@ -105,6 +106,23 @@ module LlmGateway
         else
           self.class.name.split("::").last.gsub(/Adapter$/, "").downcase
         end
+      end
+
+      def sanitize_messages(messages)
+        return messages unless input_sanitizer
+
+        target_provider = LlmGateway::Client.provider_id_from_client(client)
+        target_api = stream_api_name
+        target_model = client.model_key
+
+        return messages if target_provider.nil? || target_api.nil? || target_model.nil?
+
+        input_sanitizer.sanitize(
+          messages,
+          target_provider: target_provider,
+          target_api: target_api,
+          target_model: target_model
+        )
       end
 
       def normalize_system(system)

--- a/lib/llm_gateway/adapters/claude/messages_adapter.rb
+++ b/lib/llm_gateway/adapters/claude/messages_adapter.rb
@@ -2,6 +2,7 @@
 
 require_relative "../adapter"
 require_relative "../anthropic_option_mapper"
+require_relative "../input_message_sanitizer"
 require_relative "input_mapper"
 require_relative "output_mapper"
 require_relative "stream_mapper"
@@ -14,6 +15,7 @@ module LlmGateway
           super(
             client,
             input_mapper: InputMapper,
+            input_sanitizer: LlmGateway::Adapters::InputMessageSanitizer,
             output_mapper: OutputMapper,
             file_output_mapper: FileOutputMapper,
             option_mapper: AnthropicOptionMapper,

--- a/lib/llm_gateway/adapters/groq/chat_completions_adapter.rb
+++ b/lib/llm_gateway/adapters/groq/chat_completions_adapter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../adapter"
+require_relative "../input_message_sanitizer"
 require_relative "input_mapper"
 require_relative "output_mapper"
 require_relative "option_mapper"
@@ -13,6 +14,7 @@ module LlmGateway
           super(
             client,
             input_mapper: InputMapper,
+            input_sanitizer: LlmGateway::Adapters::InputMessageSanitizer,
             output_mapper: OutputMapper,
             option_mapper: OptionMapper,
             client_method: :chat

--- a/lib/llm_gateway/adapters/input_message_sanitizer.rb
+++ b/lib/llm_gateway/adapters/input_message_sanitizer.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module LlmGateway
+  module Adapters
+    class InputMessageSanitizer
+      def self.sanitize(messages, target_provider:, target_api:, target_model:)
+        return messages unless messages.is_a?(Array)
+
+        messages.map do |message|
+          sanitize_message(
+            message,
+            target_provider: target_provider,
+            target_api: target_api,
+            target_model: target_model
+          )
+        end
+      end
+
+      def self.sanitize_message(message, target_provider:, target_api:, target_model:)
+        return message unless message.is_a?(Hash)
+
+        role = message[:role] || message["role"]
+        content = message[:content] || message["content"]
+        return message unless role == "assistant" && content.is_a?(Array)
+        return message unless message_metadata_present?(message)
+
+        same_model_replay = same_model_replay?(message, target_provider:, target_api:, target_model:)
+
+        sanitized_content = content.each_with_object([]) do |block, acc|
+          sanitized = sanitize_content_block(block, same_model_replay: same_model_replay)
+          next if sanitized.nil?
+
+          if sanitized.is_a?(Array)
+            acc.concat(sanitized)
+          else
+            acc << sanitized
+          end
+        end
+
+        message.merge(content: sanitized_content)
+      end
+
+      def self.sanitize_content_block(block, same_model_replay:)
+        return block unless block.is_a?(Hash)
+
+        type = block[:type] || block["type"]
+        return block unless %w[thinking reasoning].include?(type)
+        return block if same_model_replay
+
+        text = extract_reasoning_text(block)
+        return nil if text.nil? || text.strip.empty?
+
+        { type: "text", text: text }
+      end
+
+      def self.extract_reasoning_text(block)
+        return block[:thinking] if block[:thinking].is_a?(String)
+        return block[:reasoning] if block[:reasoning].is_a?(String)
+
+        summary = block[:summary]
+        if summary.is_a?(Array)
+          text = summary.filter_map do |item|
+            next item if item.is_a?(String)
+            next unless item.is_a?(Hash)
+
+            item[:text] || item[:summary_text] || item[:reasoning]
+          end.join("\n")
+          return text unless text.empty?
+        end
+
+        nil
+      end
+
+      def self.same_model_replay?(message, target_provider:, target_api:, target_model:)
+        provider = message[:provider] || message["provider"]
+        api = message[:api] || message["api"]
+        model = message[:model] || message["model"]
+
+        provider == target_provider && api == target_api && model == target_model
+      end
+
+      def self.message_metadata_present?(message)
+        provider = message[:provider] || message["provider"]
+        api = message[:api] || message["api"]
+        model = message[:model] || message["model"]
+
+        !provider.nil? && !api.nil? && !model.nil?
+      end
+
+      private_class_method :sanitize_message, :sanitize_content_block, :extract_reasoning_text, :same_model_replay?, :message_metadata_present?
+    end
+  end
+end

--- a/lib/llm_gateway/adapters/open_ai/chat_completions/input_message_sanitizer.rb
+++ b/lib/llm_gateway/adapters/open_ai/chat_completions/input_message_sanitizer.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require_relative "../../input_message_sanitizer"
+
+module LlmGateway
+  module Adapters
+    module OpenAi
+      module ChatCompletions
+        class InputMessageSanitizer < LlmGateway::Adapters::InputMessageSanitizer
+          def self.sanitize(messages, target_provider:, target_api:, target_model:)
+            sanitized = super
+            normalize_tool_call_ids(sanitized, target_provider: target_provider)
+          end
+
+          def self.normalize_tool_call_ids(messages, target_provider:)
+            return messages unless messages.is_a?(Array)
+
+            id_map = {}
+
+            messages.map do |message|
+              next message unless message.is_a?(Hash) && message[:content].is_a?(Array)
+
+              content = message[:content].map do |block|
+                next block unless block.is_a?(Hash)
+
+                type = block[:type] || block["type"]
+
+                case type
+                when "tool_use", "function"
+                  original_id = block[:id] || block["id"]
+                  normalized_id = normalize_tool_call_id(original_id, target_provider: target_provider)
+                  id_map[original_id] = normalized_id if original_id && normalized_id
+                  block.merge(id: normalized_id)
+                when "tool_result"
+                  original_tool_use_id = block[:tool_use_id] || block["tool_use_id"]
+                  normalized_tool_use_id = id_map[original_tool_use_id] || normalize_tool_call_id(original_tool_use_id, target_provider: target_provider)
+                  block.merge(tool_use_id: normalized_tool_use_id)
+                else
+                  block
+                end
+              end
+
+              message.merge(content: content)
+            end
+          end
+
+          def self.normalize_tool_call_id(id, target_provider:)
+            return id unless id.is_a?(String)
+
+            if id.include?("|")
+              call_id = id.split("|", 2).first
+              call_id.gsub(/[^a-zA-Z0-9_-]/, "_")[0, 40]
+            elsif target_provider == "openai"
+              id[0, 40]
+            else
+              id
+            end
+          end
+
+          private_class_method :normalize_tool_call_ids, :normalize_tool_call_id
+        end
+      end
+    end
+  end
+end

--- a/lib/llm_gateway/adapters/open_ai/chat_completions_adapter.rb
+++ b/lib/llm_gateway/adapters/open_ai/chat_completions_adapter.rb
@@ -2,6 +2,7 @@
 
 require_relative "../adapter"
 require_relative "chat_completions/input_mapper"
+require_relative "chat_completions/input_message_sanitizer"
 require_relative "chat_completions/output_mapper"
 require_relative "chat_completions/option_mapper"
 require_relative "file_output_mapper"
@@ -15,6 +16,7 @@ module LlmGateway
           super(
             client,
             input_mapper: ChatCompletions::InputMapper,
+            input_sanitizer: ChatCompletions::InputMessageSanitizer,
             output_mapper: ChatCompletions::OutputMapper,
             file_output_mapper: FileOutputMapper,
             option_mapper: ChatCompletions::OptionMapper,

--- a/lib/llm_gateway/adapters/open_ai/responses/stream_mapper.rb
+++ b/lib/llm_gateway/adapters/open_ai/responses/stream_mapper.rb
@@ -13,7 +13,6 @@ module LlmGateway
 
             event_type = chunk[:event]
             data = chunk[:data] || {}
-
             raise_stream_error!(data) if event_type == "error" || data[:error] || data[:type] == "error"
 
             case event_type
@@ -186,7 +185,6 @@ module LlmGateway
 
           def map_response_completed(response)
             stash_response(response)
-
             AssistantStreamMessageEvent.new(
               type: message_started? ? :message_delta : :message_start,
               delta: pending_message_attributes.merge(role: pending_message_attributes[:role] || "assistant", stop_reason: stop_reason_for(response)),
@@ -213,7 +211,7 @@ module LlmGateway
             output = response[:output] || []
             last_item = output.last || {}
 
-            last_item[:type] == "function_call" ? "tool_use" : "stop"
+            tool_state.any? || last_item[:type] == "function_call" ? "tool_use" : "stop"
           end
 
           def ensure_message_started(role: "assistant")

--- a/lib/llm_gateway/adapters/open_ai/responses_adapter.rb
+++ b/lib/llm_gateway/adapters/open_ai/responses_adapter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../adapter"
+require_relative "../input_message_sanitizer"
 require_relative "responses/input_mapper"
 require_relative "responses/output_mapper"
 require_relative "responses/option_mapper"
@@ -15,6 +16,7 @@ module LlmGateway
           super(
             client,
             input_mapper: Responses::InputMapper,
+            input_sanitizer: LlmGateway::Adapters::InputMessageSanitizer,
             output_mapper: Responses::OutputMapper,
             file_output_mapper: FileOutputMapper,
             option_mapper: Responses::OptionMapper,

--- a/lib/llm_gateway/adapters/openai_codex/responses_adapter.rb
+++ b/lib/llm_gateway/adapters/openai_codex/responses_adapter.rb
@@ -6,6 +6,7 @@ require_relative "option_mapper"
 require_relative "../open_ai/responses/stream_mapper"
 require_relative "../open_ai/file_output_mapper"
 require_relative "input_mapper"
+require_relative "../input_message_sanitizer"
 
 module LlmGateway
   module Adapters
@@ -25,6 +26,7 @@ module LlmGateway
           super(
             client,
             input_mapper: OpenAiCodex::InputMapper,
+            input_sanitizer: LlmGateway::Adapters::InputMessageSanitizer,
             output_mapper: OpenAi::Responses::OutputMapper,
             file_output_mapper: OpenAi::FileOutputMapper,
             option_mapper: OptionMapper,

--- a/lib/llm_gateway/client.rb
+++ b/lib/llm_gateway/client.rb
@@ -62,7 +62,7 @@ module LlmGateway
       when LlmGateway::Clients::Groq
         "groq"
       else
-        raise LlmGateway::Errors::UnsupportedProvider, client.class.name
+        client.class.name.downcase
       end
     end
 

--- a/scripts/generate_handoff_live_fixture.rb
+++ b/scripts/generate_handoff_live_fixture.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+require "json"
+require "time"
+require "fileutils"
+require 'debug'
+require_relative "../lib/llm_gateway"
+require_relative "../test/utils/calculator_tool_helper"
+
+class HandoffLiveFixtureGenerator
+  include CalculatorToolHelper
+
+  PAIRS = [
+    { provider: "openai_apikey_completions", model: "gpt-5.1" },
+    { provider: "openai_apikey_responses", model: "gpt-5.4" },
+    { provider: "openai_oauth_codex", model: "gpt-5.4" },
+    { provider: "anthropic_apikey_messages", model: "claude-sonnet-4-20250514" }
+  ].freeze
+
+  FIXTURE_PATH = File.expand_path("../test/fixtures/handoff_live_fixture.json", __dir__)
+
+  def run
+    flat_transcript = []
+    skipped = []
+
+    PAIRS.each do |pair|
+      begin
+        adapter = load_provider(provider: pair[:provider], model: pair[:model])
+        mini_context = generate_mini_context(adapter)
+        flat_transcript.concat(mini_context.map(&:to_h))
+        puts "[ok] #{pair[:provider]} / #{pair[:model]}"
+      rescue StandardError => e
+        skipped << pair.merge(error: e.message)
+        puts "[skip] #{pair[:provider]} / #{pair[:model]} -> #{e.message}"
+      ensure
+        LlmGateway.reset_configuration!
+      end
+    end
+
+    FileUtils.mkdir_p(File.dirname(FIXTURE_PATH))
+    File.write(FIXTURE_PATH, JSON.pretty_generate(flat_transcript) + "\n")
+
+    puts "\nWrote fixture: #{FIXTURE_PATH}"
+    puts "Messages: #{flat_transcript.length}"
+    puts "Skipped pairs: #{skipped.length}"
+  end
+
+  private
+
+  def generate_mini_context(adapter)
+    transcript = [
+      {
+        role: "user",
+        content: "Think hard about this, then use the math_operation tool to double 21 by multiplying 21 and 2. Call the tool."
+      }
+    ]
+
+    first = adapter.stream(transcript, tools: [ math_operation_tool ], reasoning: "high")
+    raise first.error_message if first.stop_reason == "error"
+
+    transcript << first
+
+    tool_call = first.content.find { |block| block.type == "tool_use" && block.name == "math_operation" }
+    raise "model did not call math_operation" unless tool_call
+
+    tool_result = {
+      role: "developer",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: tool_call.id,
+          content: evaluate_math_operation(tool_call.input).to_s
+        }
+      ]
+    }
+    transcript << tool_result
+
+    second = adapter.stream(
+      transcript.map { |m| m.respond_to?(:to_h) ? m.to_h : m },
+      tools: [ math_operation_tool ],
+      reasoning: "high"
+    )
+    raise second.error_message if second.stop_reason == "error"
+
+    transcript << second
+    transcript
+  end
+
+  def load_provider(provider:, model:)
+    config = {
+      "provider" => provider,
+      "model_key" => model
+    }
+
+    case provider
+    when "openai_apikey_completions", "openai_apikey_responses"
+      api_key = ENV["OPENAI_API_KEY"].to_s
+      raise "missing OPENAI_API_KEY" if api_key.empty?
+
+      config["api_key"] = api_key
+    when "anthropic_apikey_messages"
+      api_key = ENV["ANTHROPIC_API_KEY"].to_s
+      raise "missing ANTHROPIC_API_KEY" if api_key.empty?
+
+      config["api_key"] = api_key
+    when "openai_oauth_codex"
+      creds = load_auth_credentials("openai")
+      config["api_key"] = oauth_access_token_for("openai")
+      config["account_id"] = creds["account_id"] if creds["account_id"]
+    else
+      raise ArgumentError, "Unsupported provider: #{provider}"
+    end
+
+    LlmGateway.build_provider(config)
+  end
+
+  def auth_file_path
+    File.expand_path(ENV.fetch("LLM_GATEWAY_AUTH_FILE", "~/.config/llm_gateway/auth.json"))
+  end
+
+  def load_auth_credentials(provider)
+    path = auth_file_path
+    raise "missing auth file at #{path}" unless File.exist?(path)
+
+    auth = JSON.parse(File.read(path))
+    creds = auth[provider]
+    raise "missing #{provider} credentials in #{path}" unless creds
+
+    creds
+  end
+
+  def persist_auth_credentials(provider, attributes)
+    path = auth_file_path
+    FileUtils.mkdir_p(File.dirname(path))
+
+    auth = File.exist?(path) ? JSON.parse(File.read(path)) : {}
+    auth[provider] ||= {}
+    auth[provider].merge!(attributes)
+
+    File.write(path, JSON.pretty_generate(auth) + "\n")
+  end
+
+  def oauth_access_token_for(provider)
+    creds = load_auth_credentials(provider)
+
+    case provider
+    when "openai"
+      token = LlmGateway::Clients::OpenAi.new.get_oauth_access_token(
+        access_token: creds["access_token"],
+        refresh_token: creds["refresh_token"],
+        expires_at: creds["expires_at"],
+        account_id: creds["account_id"]
+      ) do |access_token, refresh_token, expires_at|
+        persist_auth_credentials("openai", {
+          "access_token" => access_token,
+          "refresh_token" => refresh_token,
+          "expires_at" => expires_at&.iso8601
+        })
+      end
+
+      persist_auth_credentials("openai", { "access_token" => token }) if token != creds["access_token"]
+      token
+    else
+      raise ArgumentError, "Unsupported OAuth provider: #{provider}"
+    end
+  end
+end
+
+HandoffLiveFixtureGenerator.new.run

--- a/scripts/generate_handoff_media_fixture.rb
+++ b/scripts/generate_handoff_media_fixture.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require "json"
+require "time"
+require "fileutils"
+require_relative "../lib/llm_gateway"
+require_relative "../test/utils/readfile_tool_helper"
+
+class HandoffMediaLiveFixtureGenerator
+  include ReadfileToolHelper
+
+  PAIRS = [
+    { provider: "openai_apikey_completions", model: "gpt-5.1" },
+    { provider: "openai_apikey_responses", model: "gpt-5.4" },
+    { provider: "openai_oauth_codex", model: "gpt-5.4" },
+    { provider: "anthropic_apikey_messages", model: "claude-sonnet-4-20250514" }
+  ].freeze
+
+  FIXTURE_PATH = File.expand_path("../test/fixtures/handoff_media_live_fixture.json", __dir__)
+
+  def run
+    flat_transcript = []
+    skipped = []
+
+    PAIRS.each do |pair|
+      begin
+        adapter = load_provider(provider: pair[:provider], model: pair[:model])
+        mini_context = generate_mini_context(adapter)
+        flat_transcript.concat(mini_context.map(&:to_h))
+        puts "[ok] #{pair[:provider]} / #{pair[:model]}"
+      rescue StandardError => e
+        skipped << pair.merge(error: e.message)
+        puts "[skip] #{pair[:provider]} / #{pair[:model]} -> #{e.message}"
+      ensure
+        LlmGateway.reset_configuration!
+      end
+    end
+
+    FileUtils.mkdir_p(File.dirname(FIXTURE_PATH))
+    File.write(FIXTURE_PATH, JSON.pretty_generate(flat_transcript) + "\n")
+
+    puts "\nWrote fixture: #{FIXTURE_PATH}"
+    puts "Messages: #{flat_transcript.length}"
+    puts "Skipped pairs: #{skipped.length}"
+  end
+
+  private
+
+  def generate_mini_context(adapter)
+    transcript = [
+      {
+        role: "user",
+        content: "Use the readfile tool with path test/fixtures/red-circle.png and tell me what is in the image."
+      }
+    ]
+
+    first = adapter.stream(transcript, tools: [ readfile_tool ], reasoning: "high")
+    raise first.error_message if first.stop_reason == "error"
+
+    transcript << first
+
+    tool_call = first.content.find { |block| block.type == "tool_use" && block.name == "readfile" }
+    raise "model did not call readfile" unless tool_call
+
+    transcript << {
+      role: "developer",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: tool_call.id,
+          content: evaluate_readfile(tool_call.input)
+        }
+      ]
+    }
+
+    second = adapter.stream(
+      transcript.map { |m| m.respond_to?(:to_h) ? m.to_h : m },
+      tools: [ readfile_tool ],
+      reasoning: "high"
+    )
+    raise second.error_message if second.stop_reason == "error"
+
+    transcript << second
+    transcript
+  end
+
+  def load_provider(provider:, model:)
+    config = {
+      "provider" => provider,
+      "model_key" => model
+    }
+
+    case provider
+    when "openai_apikey_completions", "openai_apikey_responses"
+      api_key = ENV["OPENAI_API_KEY"].to_s
+      raise "missing OPENAI_API_KEY" if api_key.empty?
+
+      config["api_key"] = api_key
+    when "anthropic_apikey_messages"
+      api_key = ENV["ANTHROPIC_API_KEY"].to_s
+      raise "missing ANTHROPIC_API_KEY" if api_key.empty?
+
+      config["api_key"] = api_key
+    when "openai_oauth_codex"
+      creds = load_auth_credentials("openai")
+      config["api_key"] = oauth_access_token_for("openai")
+      config["account_id"] = creds["account_id"] if creds["account_id"]
+    else
+      raise ArgumentError, "Unsupported provider: #{provider}"
+    end
+
+    LlmGateway.build_provider(config)
+  end
+
+  def auth_file_path
+    File.expand_path(ENV.fetch("LLM_GATEWAY_AUTH_FILE", "~/.config/llm_gateway/auth.json"))
+  end
+
+  def load_auth_credentials(provider)
+    path = auth_file_path
+    raise "missing auth file at #{path}" unless File.exist?(path)
+
+    auth = JSON.parse(File.read(path))
+    creds = auth[provider]
+    raise "missing #{provider} credentials in #{path}" unless creds
+
+    creds
+  end
+
+  def persist_auth_credentials(provider, attributes)
+    path = auth_file_path
+    FileUtils.mkdir_p(File.dirname(path))
+
+    auth = File.exist?(path) ? JSON.parse(File.read(path)) : {}
+    auth[provider] ||= {}
+    auth[provider].merge!(attributes)
+
+    File.write(path, JSON.pretty_generate(auth) + "\n")
+  end
+
+  def oauth_access_token_for(provider)
+    creds = load_auth_credentials(provider)
+
+    case provider
+    when "openai"
+      token = LlmGateway::Clients::OpenAi.new.get_oauth_access_token(
+        access_token: creds["access_token"],
+        refresh_token: creds["refresh_token"],
+        expires_at: creds["expires_at"],
+        account_id: creds["account_id"]
+      ) do |access_token, refresh_token, expires_at|
+        persist_auth_credentials("openai", {
+          "access_token" => access_token,
+          "refresh_token" => refresh_token,
+          "expires_at" => expires_at&.iso8601
+        })
+      end
+
+      persist_auth_credentials("openai", { "access_token" => token }) if token != creds["access_token"]
+      token
+    else
+      raise ArgumentError, "Unsupported OAuth provider: #{provider}"
+    end
+  end
+end
+
+HandoffMediaLiveFixtureGenerator.new.run

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -5,6 +5,10 @@ require "test_helper"
 
 class CacheTest < Test
   class TestClient
+    attr_reader :model_key
+    def initialize
+      @model_key = "claude-3"
+    end
     CHAT_RESPONSE = {
       id: "msg_123",
       model: "claude-3",

--- a/test/fixtures/handoff_live_fixture.json
+++ b/test/fixtures/handoff_live_fixture.json
@@ -1,0 +1,269 @@
+[
+  {
+    "role": "user",
+    "content": "Think hard about this, then use the math_operation tool to double 21 by multiplying 21 and 2. Call the tool."
+  },
+  {
+    "id": "chatcmpl-DRw3SegtQRvgf86rt5lvu6E1adD2W",
+    "model": "gpt-5.1-2025-11-13",
+    "usage": {
+      "input_tokens": 189,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "output_tokens": 80,
+      "reasoning_tokens": 49
+    },
+    "role": "assistant",
+    "stop_reason": "tool_use",
+    "provider": "openai",
+    "api": "completions",
+    "content": [
+      {
+        "id": "call_Zu112TyzOtdDOW9bvWtglzqD",
+        "type": "tool_use",
+        "name": "math_operation",
+        "input": {
+          "a": 21,
+          "b": 2,
+          "operation": "multiply"
+        }
+      }
+    ]
+  },
+  {
+    "role": "developer",
+    "content": [
+      {
+        "type": "tool_result",
+        "tool_use_id": "call_Zu112TyzOtdDOW9bvWtglzqD",
+        "content": "42"
+      }
+    ]
+  },
+  {
+    "id": "chatcmpl-DRw3fnFMJwyKr8wuWiRtqi7uACZkq",
+    "model": "gpt-5.1-2025-11-13",
+    "usage": {
+      "input_tokens": 226,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "output_tokens": 4,
+      "reasoning_tokens": 0
+    },
+    "role": "assistant",
+    "stop_reason": "stop",
+    "provider": "openai",
+    "api": "completions",
+    "content": [
+      {
+        "type": "text",
+        "text": "42"
+      }
+    ]
+  },
+  {
+    "role": "user",
+    "content": "Think hard about this, then use the math_operation tool to double 21 by multiplying 21 and 2. Call the tool."
+  },
+  {
+    "id": "resp_094ddc157c4cf5230069d4bfce75588196bc6cd5428168c7fb",
+    "model": "gpt-5.4-2026-03-05",
+    "usage": {
+      "input_tokens": 107,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "output_tokens": 70,
+      "reasoning_tokens": 42
+    },
+    "role": "assistant",
+    "stop_reason": "tool_use",
+    "provider": "openai",
+    "api": "responses",
+    "content": [
+      {
+        "type": "reasoning",
+        "reasoning": "**Calculating multiplication**\n\nI see that I need to use the math_operation tool in commentary. The user is prompting me to think hard about the task, but it seems like I can keep it straightforward. I should just call the tool to multiply 21 and 2 directly without overthinking it. So I'll go ahead and do that without getting caught up in too much reasoning. It looks like I’m all set to perform this multiplication!",
+        "signature": ""
+      },
+      {
+        "id": "call_hJseujYbLEbOyyrpc0XkTOkD",
+        "type": "tool_use",
+        "name": "math_operation",
+        "input": {
+          "a": 21,
+          "b": 2,
+          "operation": "multiply"
+        }
+      }
+    ]
+  },
+  {
+    "role": "developer",
+    "content": [
+      {
+        "type": "tool_result",
+        "tool_use_id": "call_hJseujYbLEbOyyrpc0XkTOkD",
+        "content": "42"
+      }
+    ]
+  },
+  {
+    "id": "resp_01e2dfcfe88ef7600069d4bfd73a9c8193ae4d945073d7060a",
+    "model": "gpt-5.4-2026-03-05",
+    "usage": {
+      "input_tokens": 145,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "output_tokens": 5,
+      "reasoning_tokens": 0
+    },
+    "role": "assistant",
+    "stop_reason": "stop",
+    "provider": "openai",
+    "api": "responses",
+    "content": [
+      {
+        "type": "text",
+        "text": "42"
+      }
+    ]
+  },
+  {
+    "role": "user",
+    "content": "Think hard about this, then use the math_operation tool to double 21 by multiplying 21 and 2. Call the tool."
+  },
+  {
+    "id": "resp_0dfb6412ee59614a0169d4bfd8d0f08191839cf67b5f91eeaa",
+    "model": "gpt-5.4",
+    "usage": {
+      "input_tokens": 117,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "output_tokens": 49,
+      "reasoning_tokens": 21
+    },
+    "role": "assistant",
+    "stop_reason": "stop",
+    "provider": "openai",
+    "api": "responses",
+    "content": [
+      {
+        "type": "reasoning",
+        "reasoning": "",
+        "signature": ""
+      },
+      {
+        "id": "call_oZnWijR9AOEK7zjMPCc7Pmul",
+        "type": "tool_use",
+        "name": "math_operation",
+        "input": {
+          "a": 21,
+          "b": 2,
+          "operation": "multiply"
+        }
+      }
+    ]
+  },
+  {
+    "role": "developer",
+    "content": [
+      {
+        "type": "tool_result",
+        "tool_use_id": "call_oZnWijR9AOEK7zjMPCc7Pmul",
+        "content": "42"
+      }
+    ]
+  },
+  {
+    "id": "resp_09aae1053c3251af0169d4bfdd0540819191a6ffe3d7a6a654",
+    "model": "gpt-5.4",
+    "usage": {
+      "input_tokens": 155,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "output_tokens": 5,
+      "reasoning_tokens": 0
+    },
+    "role": "assistant",
+    "stop_reason": "stop",
+    "provider": "openai",
+    "api": "responses",
+    "content": [
+      {
+        "type": "text",
+        "text": "42"
+      }
+    ]
+  },
+  {
+    "role": "user",
+    "content": "Think hard about this, then use the math_operation tool to double 21 by multiplying 21 and 2. Call the tool."
+  },
+  {
+    "id": "msg_01JoWVZRYDBEwPyJVBbXA9w6",
+    "model": "claude-sonnet-4-20250514",
+    "usage": {
+      "input_tokens": 1008,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "output_tokens": 190,
+      "reasoning_tokens": 0
+    },
+    "role": "assistant",
+    "stop_reason": "tool_use",
+    "provider": "anthropic",
+    "api": "messages",
+    "content": [
+      {
+        "type": "reasoning",
+        "reasoning": "The user is asking me to double 21 by multiplying 21 and 2. This is a straightforward math operation.\n\nI need to use the math_operation tool with:\n- a = 21\n- b = 2  \n- operation = \"multiply\"\n\nLet me call the tool with these parameters.",
+        "signature": "Eq8DCmIIDBgCKkC3tsKyBe9/TiIE7ZhITQe4Ff42v1VOq3VgqMK1Od4LX21XVzcS8M9/Ee1/Kbjad/nacJZgO8vMDOAsmjvuDjqsMhhjbGF1ZGUtc29ubmV0LTQtMjAyNTA1MTQ4ABIM6T9P9+8DA2b2BwOTGgzCc609ODSfucad010iMEvmGC6nQhVjizy0XTOFJIvwbbisOqRKf3Ou0iY70TNTxeCM1OPRqQxL/tVXtPKo7Sr6AWQcRX7uGabAPk0w5u5o9lfenaaKf/yc5MfXemIbpUszckrmVAoVk+7Cz0QDpdCk7D/AswqSC1upPv9oGfIOhuz0X+6z3KL23LEr2XzEN56/2bkd3chWIxRS/Vw4hMAsf3wN+cG0c9CHHg7USXM8exQJEkVxfj5qeN1YLMkY8Jc0Q+qwiyl4eBud7CNHNqPn6AL9MSMZIIseOudfOXDBDiS3oSn77MZg2Z86oC5bJ31TlhZqDYz9/mdimeQs57tFIJgEkp4aZxgtCg6GoKNWJ8L1PswiMwB5Ky4CghI9DPQsNElFul9IFr2mjPybMcgPkc9Ga6EAuT3Tw9cYAQ=="
+      },
+      {
+        "type": "text",
+        "text": "I'll use the math_operation tool to multiply 21 by 2 to double it."
+      },
+      {
+        "id": "toolu_01UWAwgrrBkDjzVqFUmtkESa",
+        "type": "tool_use",
+        "name": "math_operation",
+        "input": {
+          "a": 21,
+          "b": 2,
+          "operation": "multiply"
+        }
+      }
+    ]
+  },
+  {
+    "role": "developer",
+    "content": [
+      {
+        "type": "tool_result",
+        "tool_use_id": "toolu_01UWAwgrrBkDjzVqFUmtkESa",
+        "content": "42"
+      }
+    ]
+  },
+  {
+    "id": "msg_01BTUwvscWaNgkeREvswdB56",
+    "model": "claude-sonnet-4-20250514",
+    "usage": {
+      "input_tokens": 1406,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "output_tokens": 31,
+      "reasoning_tokens": 0
+    },
+    "role": "assistant",
+    "stop_reason": "stop",
+    "provider": "anthropic",
+    "api": "messages",
+    "content": [
+      {
+        "type": "text",
+        "text": "The result of doubling 21 by multiplying it by 2 is 42."
+      }
+    ]
+  }
+]

--- a/test/fixtures/handoff_media_live_fixture.json
+++ b/test/fixtures/handoff_media_live_fixture.json
@@ -1,0 +1,297 @@
+[
+  {
+    "role": "user",
+    "content": "Use the readfile tool with path test/fixtures/red-circle.png and tell me what is in the image."
+  },
+  {
+    "id": "chatcmpl-DRwpKkO2eAn4E7dCaHjI0gEFWEiSv",
+    "model": "gpt-5.1-2025-11-13",
+    "usage": {
+      "input_tokens": 154,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "output_tokens": 158,
+      "reasoning_tokens": 130
+    },
+    "role": "assistant",
+    "stop_reason": "tool_use",
+    "provider": "openai",
+    "api": "completions",
+    "content": [
+      {
+        "id": "call_B3cofRsZGydQAi43AznrACwG",
+        "type": "tool_use",
+        "name": "readfile",
+        "input": {
+          "path": "test/fixtures/red-circle.png"
+        }
+      }
+    ]
+  },
+  {
+    "role": "developer",
+    "content": [
+      {
+        "type": "tool_result",
+        "tool_use_id": "call_B3cofRsZGydQAi43AznrACwG",
+        "content": [
+          {
+            "type": "text",
+            "text": "Read image file [image/png]"
+          },
+          {
+            "type": "image",
+            "data": "iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAABmJLR0QA/wD/AP+gvaeTAAAJuklEQVR4nO3df2hV9R/H8deNLSl1a6Zs17S1pmsTolaUJdoPHJaU/RQ00DQK/4hIooIiI6J/FPpF/SdJ5ciMMDD7gThRyyChH5DR5kQXarU5N62c2lzs+8eHfZGwN3Ode9/3fs7zAUP/iPm+Oz33Ofecc8/JDA4ODgrAWZ3nPQBQyAgEMBAIYCAQwEAggIFAAAOBAAYCAQwEAhgIBDAQCGAgEMBAIICBQAADgQAGAgEMBAIYCAQwEAhgIBDAQCCAgUAAA4EABgIBDAQCGAgEMBAIYCAQwEAggIFAAAOBAAYCAQwEAhgIBDAQCGAgEMBAIICBQAADgQAGAgEMBAIYCAQwEAhgIBDAQCCAgUAAA4EABgIBDAQCGEq8B0iNnh5pzx6prU1qbw9/7+yU+vrC19Gj4U9JGj1aqqgIf44eLWWzUl1d+Kqvl664Qrr4Yt/XkxKZwcHBQe8hotTZKX35pdTSIm3ZInV0JPv9s1lp5kypqUm67TapujrZ7w9JBJKs1lZp7VppwwZp7978/tt1ddL8+dLixWGVQSII5L86ckRat05qbpa++cZ7muD666VFi6QHHpDGj/eepqgRyEgdOCC98or01lvSiRPe05zdqFHSkiXSihXS5Mne0xQlAjlXHR3S669Lq1dLp055TzM8paXSwoXSc8+FN/gYNgIZrr4+6aWXwqoxMOA9zciUlEiPPhpeR1mZ9zRFgUCGY9Om8D/WoUPekyQjm5VWrgxv6DMZ72kKGoFYOjqkhx+Wtm3zniQ3Zs+W1qzhELGBM+n/ZuNG6dpr441DkrZula66SvrwQ+9JChaB/NPp09Izz0j33hvObsfu99+lBQuk5cul/n7vaQoOu1hn+u036a67Cud8Rr5Nnx5WzspK70kKBoEM6egIl2zk+wx4oampkTZvlqZO9Z6kILCLJUm7d4frmtIehxR+UcyaJX3/vfckBYFAduwIcfz6q/ckhaOrS7rllnCxZcqlexfrhx+km2+Wjh3znqQwlZWFo3jXXOM9iZv0BrJvX1g5Oju9JylsEyZIO3eGq4VTKJ27WIcPS3PnEsdwdHen+meVvkD++ku64w7ekJ+L/fule+5J5XmS9AXy9NPpPc/xX+zaJT37rPcUeZeu9yCffBJOBKboJScqk5E++iisJimRnkAOHJAaG6XeXu9JiltFhfTtt+GEYgqkYxdrcFBaupQ4knD0qLRsmfcUeZOOQNati/uq3HxraZE++MB7iryIfxfrjz+khgbOlCetqirc46u83HuSnIp/BVmxgjhyobNTevFF7ylyLu4VZO/esHr8/bf3JHEqKQmrSG2t9yQ5E/cKsnIlceTSwIC0apX3FDkV7wpy8KA0ZUoqz/7mVWlpWKkj/Vx7vCvIqlXEkQ+nT0uvvuo9Rc7EuYJ0d4ffaCdPek+SDhdcEFbsCO84H+cK8v77xJFPJ09K69d7T5ETcQbS3Ow9QfpE+jOPbxertVWaNs17inRqa4vu3r/xrSBr13pPkF7vvec9QeLiW0Hq6vgwlJeGBumnn7ynSFRcgfzyizRpkvcU6XbokHTJJd5TJCauXaytW70nwPbt3hMkKq5AuKTdX2TbIK5drOrq8MlB+KmpCTd5iEQ8gRw5Eu7hBH89PdK4cd5TJCKeXaw9e7wnwJD2du8JEkMgSF5E24JAkLyItkU8gUS0rBc9AilAKb13bEHq6vKeIDHxBHL8uPcEGPLnn94TJCaeQCLaKEUvom1BIEheRNsinkDYxSocBAKkQzyBjBnjPQGGjB3rPUFi4gkkoo1S9CLaFgSC5EW0LeIJhF2swkEgBaiqynsCDKms9J4gMfEEEtntZopafb33BIkhECQvom1BIEheRNsino/c9vZGefPkosRHbgvQuHHRPqOiqNTURBOHFFMgknTrrd4TYPZs7wkSRSBIVmTbIJ73IFJ4mm1Et70sOplMuP1rNus9SWLiWkEmTozqCErRaWiIKg4ptkAk6b77vCdIr/nzvSdIXFy7WFK4uwmriA8eoFME6uqk667zniJ9brwxujikGAORpMWLvSdIn0h/5vHtYknhRtaXXsqTbvPlwgvDXfUjvJIhzhVk/HjpkUe8p0iPZcuijEOKdQWRwqPAamul/n7vSeI2apS0b1+055/iXEGk8KzCBx/0niJ+Dz0UbRxSzCuIFH6z1ddLAwPek8SptDTcqLqmxnuSnIl3BZHCLtZjj3lPEa/ly6OOQ4p9BZHCXf4aGsI1QkhONhtODJaVeU+SU3GvIFK4w8bLL3tPEZ833og+DikNK8iQpiaeo56UOXOkzZu9p8iL9ARy8KDU2Bg+DoqRq6iQvvtOuuwy70nyIv5drCGTJ0vvvBM+s4CRyWSkt99OTRxSmgKRpDvvDEdeMDJPPSXdfbf3FHmVnl2sIf390k03Sbt2eU9SXGbMkLZvD+c+UiR9gUhSd7c0a1ZUT2PNqdpa6auvorql6HClaxdryIQJ0mefRffx0JzIZqUtW1IZh5TWQCTp8svDocqLLvKepHCVlUmffhr92XJLegORpCuvlDZulMrLvScpPOXlIY7GRu9JXKXzPcg//fijdPvtXI4ypKpK+vxz6eqrvSdxRyBDOjpCJO3t3pP4Gtr1nDLFe5KCkO5drDPV1EhffCFNn+49iZ8ZM6SvvyaOMxDImSorpZ07pRdekM5L0Y8mk5Eef1zati0c4cP/sYv1bzZtkpYuDY9ViFl5ubRmjXT//d6TFKQU/Zo8R/PmhYvympq8J8mdOXOk3buJw0AglurqcJLs44/DxY6xmDhRevfd8GY8pteVAwQyHPPmhUPBTzwhlZR4TzNypaXSk0+GS2y4ocWw8B7kXP38s/Taa9Lq1dKpU97TDM/550sLFkjPPy9Nneo9TVEhkJHq6gqhvPmmdOKE9zRnN2qUtGRJCGPSJO9pihKB/Fc9PdL69VJzc+FcQn/DDeFeuQsXRvW8QA8EkqT29hDKhg1Sa2t+/+1p08LzORYtYjcqQQSSK4cPSzt2SC0t4Wv//mS/fzYrzZwZDkPPncvRqBwhkHzp7Q0rTFtbOIrU3i51dkp9feHeXceOScePh/92zJhwGf7YseHvlZXh2RtnflVU+L6elCAQwMB5EMBAIICBQAADgQAGAgEMBAIYCAQwEAhgIBDAQCCAgUAAA4EABgIBDAQCGAgEMBAIYCAQwEAggIFAAAOBAAYCAQwEAhgIBDAQCGAgEMBAIICBQAADgQAGAgEMBAIYCAQwEAhgIBDAQCCAgUAAA4EABgIBDAQCGAgEMBAIYCAQwEAggIFAAAOBAAYCAQwEAhgIBDAQCGAgEMDwP4yLqLwXdlfVAAAAAElFTkSuQmCC",
+            "media_type": "image/png"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "chatcmpl-DRwpNlESyJWCRaUPr2IAvTQtCjFNd",
+    "model": "gpt-5.1-2025-11-13",
+    "usage": {
+      "input_tokens": 195,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "output_tokens": 176,
+      "reasoning_tokens": 142
+    },
+    "role": "assistant",
+    "stop_reason": "stop",
+    "provider": "openai",
+    "api": "completions",
+    "content": [
+      {
+        "type": "text",
+        "text": "The image is a simple graphic of a red circle, likely centered on a plain or transparent background with no other visible elements."
+      }
+    ]
+  },
+  {
+    "role": "user",
+    "content": "Use the readfile tool with path test/fixtures/red-circle.png and tell me what is in the image."
+  },
+  {
+    "id": "resp_03f1b0d4b55488150069d4cb549a288190a605cf6ae7e8ece3",
+    "model": "gpt-5.4-2026-03-05",
+    "usage": {
+      "input_tokens": 72,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "output_tokens": 61,
+      "reasoning_tokens": 36
+    },
+    "role": "assistant",
+    "stop_reason": "tool_use",
+    "provider": "openai",
+    "api": "responses",
+    "content": [
+      {
+        "type": "reasoning",
+        "reasoning": "**Using readfile tool**\n\nI'm needing to comply by using the readfile tool. I should inspect the binary, which might return either base64 or raw data? It's important to use the commentary channel for this tool. So, let's go ahead and do the readfile function! That should set me on the right path for what I need. I'm looking forward to seeing what results I get!",
+        "signature": ""
+      },
+      {
+        "id": "call_EVbpgd1XysoV56HBtxvSdfo3",
+        "type": "tool_use",
+        "name": "readfile",
+        "input": {
+          "path": "test/fixtures/red-circle.png"
+        }
+      }
+    ]
+  },
+  {
+    "role": "developer",
+    "content": [
+      {
+        "type": "tool_result",
+        "tool_use_id": "call_EVbpgd1XysoV56HBtxvSdfo3",
+        "content": [
+          {
+            "type": "text",
+            "text": "Read image file [image/png]"
+          },
+          {
+            "type": "image",
+            "data": "iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAABmJLR0QA/wD/AP+gvaeTAAAJuklEQVR4nO3df2hV9R/H8deNLSl1a6Zs17S1pmsTolaUJdoPHJaU/RQ00DQK/4hIooIiI6J/FPpF/SdJ5ciMMDD7gThRyyChH5DR5kQXarU5N62c2lzs+8eHfZGwN3Ode9/3fs7zAUP/iPm+Oz33Ofecc8/JDA4ODgrAWZ3nPQBQyAgEMBAIYCAQwEAggIFAAAOBAAYCAQwEAhgIBDAQCGAgEMBAIICBQAADgQAGAgEMBAIYCAQwEAhgIBDAQCCAgUAAA4EABgIBDAQCGAgEMBAIYCAQwEAggIFAAAOBAAYCAQwEAhgIBDAQCGAgEMBAIICBQAADgQAGAgEMBAIYCAQwEAhgIBDAQCCAgUAAA4EABgIBDAQCGEq8B0iNnh5pzx6prU1qbw9/7+yU+vrC19Gj4U9JGj1aqqgIf44eLWWzUl1d+Kqvl664Qrr4Yt/XkxKZwcHBQe8hotTZKX35pdTSIm3ZInV0JPv9s1lp5kypqUm67TapujrZ7w9JBJKs1lZp7VppwwZp7978/tt1ddL8+dLixWGVQSII5L86ckRat05qbpa++cZ7muD666VFi6QHHpDGj/eepqgRyEgdOCC98or01lvSiRPe05zdqFHSkiXSihXS5Mne0xQlAjlXHR3S669Lq1dLp055TzM8paXSwoXSc8+FN/gYNgIZrr4+6aWXwqoxMOA9zciUlEiPPhpeR1mZ9zRFgUCGY9Om8D/WoUPekyQjm5VWrgxv6DMZ72kKGoFYOjqkhx+Wtm3zniQ3Zs+W1qzhELGBM+n/ZuNG6dpr441DkrZula66SvrwQ+9JChaB/NPp09Izz0j33hvObsfu99+lBQuk5cul/n7vaQoOu1hn+u036a67Cud8Rr5Nnx5WzspK70kKBoEM6egIl2zk+wx4oampkTZvlqZO9Z6kILCLJUm7d4frmtIehxR+UcyaJX3/vfckBYFAduwIcfz6q/ckhaOrS7rllnCxZcqlexfrhx+km2+Wjh3znqQwlZWFo3jXXOM9iZv0BrJvX1g5Oju9JylsEyZIO3eGq4VTKJ27WIcPS3PnEsdwdHen+meVvkD++ku64w7ekJ+L/fule+5J5XmS9AXy9NPpPc/xX+zaJT37rPcUeZeu9yCffBJOBKboJScqk5E++iisJimRnkAOHJAaG6XeXu9JiltFhfTtt+GEYgqkYxdrcFBaupQ4knD0qLRsmfcUeZOOQNati/uq3HxraZE++MB7iryIfxfrjz+khgbOlCetqirc46u83HuSnIp/BVmxgjhyobNTevFF7ylyLu4VZO/esHr8/bf3JHEqKQmrSG2t9yQ5E/cKsnIlceTSwIC0apX3FDkV7wpy8KA0ZUoqz/7mVWlpWKkj/Vx7vCvIqlXEkQ+nT0uvvuo9Rc7EuYJ0d4ffaCdPek+SDhdcEFbsCO84H+cK8v77xJFPJ09K69d7T5ETcQbS3Ow9QfpE+jOPbxertVWaNs17inRqa4vu3r/xrSBr13pPkF7vvec9QeLiW0Hq6vgwlJeGBumnn7ynSFRcgfzyizRpkvcU6XbokHTJJd5TJCauXaytW70nwPbt3hMkKq5AuKTdX2TbIK5drOrq8MlB+KmpCTd5iEQ8gRw5Eu7hBH89PdK4cd5TJCKeXaw9e7wnwJD2du8JEkMgSF5E24JAkLyItkU8gUS0rBc9AilAKb13bEHq6vKeIDHxBHL8uPcEGPLnn94TJCaeQCLaKEUvom1BIEheRNsinkDYxSocBAKkQzyBjBnjPQGGjB3rPUFi4gkkoo1S9CLaFgSC5EW0LeIJhF2swkEgBaiqynsCDKms9J4gMfEEEtntZopafb33BIkhECQvom1BIEheRNsino/c9vZGefPkosRHbgvQuHHRPqOiqNTURBOHFFMgknTrrd4TYPZs7wkSRSBIVmTbIJ73IFJ4mm1Et70sOplMuP1rNus9SWLiWkEmTozqCErRaWiIKg4ptkAk6b77vCdIr/nzvSdIXFy7WFK4uwmriA8eoFME6uqk667zniJ9brwxujikGAORpMWLvSdIn0h/5vHtYknhRtaXXsqTbvPlwgvDXfUjvJIhzhVk/HjpkUe8p0iPZcuijEOKdQWRwqPAamul/n7vSeI2apS0b1+055/iXEGk8KzCBx/0niJ+Dz0UbRxSzCuIFH6z1ddLAwPek8SptDTcqLqmxnuSnIl3BZHCLtZjj3lPEa/ly6OOQ4p9BZHCXf4aGsI1QkhONhtODJaVeU+SU3GvIFK4w8bLL3tPEZ833og+DikNK8iQpiaeo56UOXOkzZu9p8iL9ARy8KDU2Bg+DoqRq6iQvvtOuuwy70nyIv5drCGTJ0vvvBM+s4CRyWSkt99OTRxSmgKRpDvvDEdeMDJPPSXdfbf3FHmVnl2sIf390k03Sbt2eU9SXGbMkLZvD+c+UiR9gUhSd7c0a1ZUT2PNqdpa6auvorql6HClaxdryIQJ0mefRffx0JzIZqUtW1IZh5TWQCTp8svDocqLLvKepHCVlUmffhr92XJLegORpCuvlDZulMrLvScpPOXlIY7GRu9JXKXzPcg//fijdPvtXI4ypKpK+vxz6eqrvSdxRyBDOjpCJO3t3pP4Gtr1nDLFe5KCkO5drDPV1EhffCFNn+49iZ8ZM6SvvyaOMxDImSorpZ07pRdekM5L0Y8mk5Eef1zati0c4cP/sYv1bzZtkpYuDY9ViFl5ubRmjXT//d6TFKQU/Zo8R/PmhYvympq8J8mdOXOk3buJw0AglurqcJLs44/DxY6xmDhRevfd8GY8pteVAwQyHPPmhUPBTzwhlZR4TzNypaXSk0+GS2y4ocWw8B7kXP38s/Taa9Lq1dKpU97TDM/550sLFkjPPy9Nneo9TVEhkJHq6gqhvPmmdOKE9zRnN2qUtGRJCGPSJO9pihKB/Fc9PdL69VJzc+FcQn/DDeFeuQsXRvW8QA8EkqT29hDKhg1Sa2t+/+1p08LzORYtYjcqQQSSK4cPSzt2SC0t4Wv//mS/fzYrzZwZDkPPncvRqBwhkHzp7Q0rTFtbOIrU3i51dkp9feHeXceOScePh/92zJhwGf7YseHvlZXh2RtnflVU+L6elCAQwMB5EMBAIICBQAADgQAGAgEMBAIYCAQwEAhgIBDAQCCAgUAAA4EABgIBDAQCGAgEMBAIYCAQwEAggIFAAAOBAAYCAQwEAhgIBDAQCGAgEMBAIICBQAADgQAGAgEMBAIYCAQwEAhgIBDAQCCAgUAAA4EABgIBDAQCGAgEMBAIYCAQwEAggIFAAAOBAAYCAQwEAhgIBDAQCGAgEMDwP4yLqLwXdlfVAAAAAElFTkSuQmCC",
+            "media_type": "image/png"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "resp_073fb2aea49f54b30069d4cb57c83c8193b5b70fefb9af4ccf",
+    "model": "gpt-5.4-2026-03-05",
+    "usage": {
+      "input_tokens": 261,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "output_tokens": 17,
+      "reasoning_tokens": 0
+    },
+    "role": "assistant",
+    "stop_reason": "stop",
+    "provider": "openai",
+    "api": "responses",
+    "content": [
+      {
+        "type": "text",
+        "text": "The image shows a solid red circle centered on a white background."
+      }
+    ]
+  },
+  {
+    "role": "user",
+    "content": "Use the readfile tool with path test/fixtures/red-circle.png and tell me what is in the image."
+  },
+  {
+    "id": "resp_0c71ead3f7e3c9500169d4cb5bb8008191b60751a9ed727054",
+    "model": "gpt-5.4",
+    "usage": {
+      "input_tokens": 82,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "output_tokens": 77,
+      "reasoning_tokens": 52
+    },
+    "role": "assistant",
+    "stop_reason": "stop",
+    "provider": "openai",
+    "api": "responses",
+    "content": [
+      {
+        "type": "reasoning",
+        "reasoning": "**Inspecting image content**\n\nI need to address the user's question by using the readfile tool to check what’s in the image located at test/fixtures/red-circle.png. Since this tool reads a file and probably returns binary data, I’ll use the commentary channel for this. It sounds like I need to inspect the binary content carefully to understand what's in the image. Let's see how this goes!",
+        "signature": ""
+      },
+      {
+        "id": "call_Kf3VCHSWxq0R3cF63EYjoob8",
+        "type": "tool_use",
+        "name": "readfile",
+        "input": {
+          "path": "test/fixtures/red-circle.png"
+        }
+      }
+    ]
+  },
+  {
+    "role": "developer",
+    "content": [
+      {
+        "type": "tool_result",
+        "tool_use_id": "call_Kf3VCHSWxq0R3cF63EYjoob8",
+        "content": [
+          {
+            "type": "text",
+            "text": "Read image file [image/png]"
+          },
+          {
+            "type": "image",
+            "data": "iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAABmJLR0QA/wD/AP+gvaeTAAAJuklEQVR4nO3df2hV9R/H8deNLSl1a6Zs17S1pmsTolaUJdoPHJaU/RQ00DQK/4hIooIiI6J/FPpF/SdJ5ciMMDD7gThRyyChH5DR5kQXarU5N62c2lzs+8eHfZGwN3Ode9/3fs7zAUP/iPm+Oz33Ofecc8/JDA4ODgrAWZ3nPQBQyAgEMBAIYCAQwEAggIFAAAOBAAYCAQwEAhgIBDAQCGAgEMBAIICBQAADgQAGAgEMBAIYCAQwEAhgIBDAQCCAgUAAA4EABgIBDAQCGAgEMBAIYCAQwEAggIFAAAOBAAYCAQwEAhgIBDAQCGAgEMBAIICBQAADgQAGAgEMBAIYCAQwEAhgIBDAQCCAgUAAA4EABgIBDAQCGEq8B0iNnh5pzx6prU1qbw9/7+yU+vrC19Gj4U9JGj1aqqgIf44eLWWzUl1d+Kqvl664Qrr4Yt/XkxKZwcHBQe8hotTZKX35pdTSIm3ZInV0JPv9s1lp5kypqUm67TapujrZ7w9JBJKs1lZp7VppwwZp7978/tt1ddL8+dLixWGVQSII5L86ckRat05qbpa++cZ7muD666VFi6QHHpDGj/eepqgRyEgdOCC98or01lvSiRPe05zdqFHSkiXSihXS5Mne0xQlAjlXHR3S669Lq1dLp055TzM8paXSwoXSc8+FN/gYNgIZrr4+6aWXwqoxMOA9zciUlEiPPhpeR1mZ9zRFgUCGY9Om8D/WoUPekyQjm5VWrgxv6DMZ72kKGoFYOjqkhx+Wtm3zniQ3Zs+W1qzhELGBM+n/ZuNG6dpr441DkrZula66SvrwQ+9JChaB/NPp09Izz0j33hvObsfu99+lBQuk5cul/n7vaQoOu1hn+u036a67Cud8Rr5Nnx5WzspK70kKBoEM6egIl2zk+wx4oampkTZvlqZO9Z6kILCLJUm7d4frmtIehxR+UcyaJX3/vfckBYFAduwIcfz6q/ckhaOrS7rllnCxZcqlexfrhx+km2+Wjh3znqQwlZWFo3jXXOM9iZv0BrJvX1g5Oju9JylsEyZIO3eGq4VTKJ27WIcPS3PnEsdwdHen+meVvkD++ku64w7ekJ+L/fule+5J5XmS9AXy9NPpPc/xX+zaJT37rPcUeZeu9yCffBJOBKboJScqk5E++iisJimRnkAOHJAaG6XeXu9JiltFhfTtt+GEYgqkYxdrcFBaupQ4knD0qLRsmfcUeZOOQNati/uq3HxraZE++MB7iryIfxfrjz+khgbOlCetqirc46u83HuSnIp/BVmxgjhyobNTevFF7ylyLu4VZO/esHr8/bf3JHEqKQmrSG2t9yQ5E/cKsnIlceTSwIC0apX3FDkV7wpy8KA0ZUoqz/7mVWlpWKkj/Vx7vCvIqlXEkQ+nT0uvvuo9Rc7EuYJ0d4ffaCdPek+SDhdcEFbsCO84H+cK8v77xJFPJ09K69d7T5ETcQbS3Ow9QfpE+jOPbxertVWaNs17inRqa4vu3r/xrSBr13pPkF7vvec9QeLiW0Hq6vgwlJeGBumnn7ynSFRcgfzyizRpkvcU6XbokHTJJd5TJCauXaytW70nwPbt3hMkKq5AuKTdX2TbIK5drOrq8MlB+KmpCTd5iEQ8gRw5Eu7hBH89PdK4cd5TJCKeXaw9e7wnwJD2du8JEkMgSF5E24JAkLyItkU8gUS0rBc9AilAKb13bEHq6vKeIDHxBHL8uPcEGPLnn94TJCaeQCLaKEUvom1BIEheRNsinkDYxSocBAKkQzyBjBnjPQGGjB3rPUFi4gkkoo1S9CLaFgSC5EW0LeIJhF2swkEgBaiqynsCDKms9J4gMfEEEtntZopafb33BIkhECQvom1BIEheRNsino/c9vZGefPkosRHbgvQuHHRPqOiqNTURBOHFFMgknTrrd4TYPZs7wkSRSBIVmTbIJ73IFJ4mm1Et70sOplMuP1rNus9SWLiWkEmTozqCErRaWiIKg4ptkAk6b77vCdIr/nzvSdIXFy7WFK4uwmriA8eoFME6uqk667zniJ9brwxujikGAORpMWLvSdIn0h/5vHtYknhRtaXXsqTbvPlwgvDXfUjvJIhzhVk/HjpkUe8p0iPZcuijEOKdQWRwqPAamul/n7vSeI2apS0b1+055/iXEGk8KzCBx/0niJ+Dz0UbRxSzCuIFH6z1ddLAwPek8SptDTcqLqmxnuSnIl3BZHCLtZjj3lPEa/ly6OOQ4p9BZHCXf4aGsI1QkhONhtODJaVeU+SU3GvIFK4w8bLL3tPEZ833og+DikNK8iQpiaeo56UOXOkzZu9p8iL9ARy8KDU2Bg+DoqRq6iQvvtOuuwy70nyIv5drCGTJ0vvvBM+s4CRyWSkt99OTRxSmgKRpDvvDEdeMDJPPSXdfbf3FHmVnl2sIf390k03Sbt2eU9SXGbMkLZvD+c+UiR9gUhSd7c0a1ZUT2PNqdpa6auvorql6HClaxdryIQJ0mefRffx0JzIZqUtW1IZh5TWQCTp8svDocqLLvKepHCVlUmffhr92XJLegORpCuvlDZulMrLvScpPOXlIY7GRu9JXKXzPcg//fijdPvtXI4ypKpK+vxz6eqrvSdxRyBDOjpCJO3t3pP4Gtr1nDLFe5KCkO5drDPV1EhffCFNn+49iZ8ZM6SvvyaOMxDImSorpZ07pRdekM5L0Y8mk5Eef1zati0c4cP/sYv1bzZtkpYuDY9ViFl5ubRmjXT//d6TFKQU/Zo8R/PmhYvympq8J8mdOXOk3buJw0AglurqcJLs44/DxY6xmDhRevfd8GY8pteVAwQyHPPmhUPBTzwhlZR4TzNypaXSk0+GS2y4ocWw8B7kXP38s/Taa9Lq1dKpU97TDM/550sLFkjPPy9Nneo9TVEhkJHq6gqhvPmmdOKE9zRnN2qUtGRJCGPSJO9pihKB/Fc9PdL69VJzc+FcQn/DDeFeuQsXRvW8QA8EkqT29hDKhg1Sa2t+/+1p08LzORYtYjcqQQSSK4cPSzt2SC0t4Wv//mS/fzYrzZwZDkPPncvRqBwhkHzp7Q0rTFtbOIrU3i51dkp9feHeXceOScePh/92zJhwGf7YseHvlZXh2RtnflVU+L6elCAQwMB5EMBAIICBQAADgQAGAgEMBAIYCAQwEAhgIBDAQCCAgUAAA4EABgIBDAQCGAgEMBAIYCAQwEAggIFAAAOBAAYCAQwEAhgIBDAQCGAgEMBAIICBQAADgQAGAgEMBAIYCAQwEAhgIBDAQCCAgUAAA4EABgIBDAQCGAgEMBAIYCAQwEAggIFAAAOBAAYCAQwEAhgIBDAQCGAgEMDwP4yLqLwXdlfVAAAAAElFTkSuQmCC",
+            "media_type": "image/png"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "resp_052bc3399e1d6ae50169d4cb61cd2c8191a5f81f42ebacff99",
+    "model": "gpt-5.4",
+    "usage": {
+      "input_tokens": 185,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "output_tokens": 17,
+      "reasoning_tokens": 0
+    },
+    "role": "assistant",
+    "stop_reason": "stop",
+    "provider": "openai",
+    "api": "responses",
+    "content": [
+      {
+        "type": "text",
+        "text": "The image shows a solid red circle centered on a white background."
+      }
+    ]
+  },
+  {
+    "role": "user",
+    "content": "Use the readfile tool with path test/fixtures/red-circle.png and tell me what is in the image."
+  },
+  {
+    "id": "msg_01RZKdzihsmKRCfSyPdFSWfR",
+    "model": "claude-sonnet-4-20250514",
+    "usage": {
+      "input_tokens": 878,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "output_tokens": 222,
+      "reasoning_tokens": 0
+    },
+    "role": "assistant",
+    "stop_reason": "tool_use",
+    "provider": "anthropic",
+    "api": "messages",
+    "content": [
+      {
+        "type": "reasoning",
+        "reasoning": "The user is asking me to use the readfile tool to read a file at the path \"test/fixtures/red-circle.png\" and then tell them what is in the image. \n\nI need to call the readfile function with the exact path they provided: \"test/fixtures/red-circle.png\"\n\nHowever, I should note that the readfile tool will return the file contents, but since this is a PNG image file, the contents will be binary data that I won't be able to interpret as an actual image. I won't be able to see or analyze the visual contents of the image - I'll only get the raw file data.\n\nLet me make the function call first and then explain this limitation.",
+        "signature": "ErUGCmIIDBgCKkDTa9w6pvYxbU8lSrjDOM92382KnxGxNCwRxw+WSPhdJnO8e8MXZtNfIlBvCZGQPx+CdziWjBbkmcdua3229VSBMhhjbGF1ZGUtc29ubmV0LTQtMjAyNTA1MTQ4ABIMyL0dM/Twiph3zpg4Ggzite5qRm01VkBP/BUiMC3OCQJBW2wCXDSqVbOUMNrde1xrPGW28oGbVsYgnKmw/JHaXZGIO0h6jrVwOfQkUSqABetpdn7eVOuK88XcBeLC1lmN8yx4CgFwkTgJDgehe/a4ScgtHspnKL8/aQnAnSF0spbAPbEU48Arvv9VQnaETjbu7UH6PQre/8h3d994sFfkgISwa6Bzzqu5Kdx/K5Xyr+lrWgvkYWFMsu7Xz+Y6fw/rnb5MKabNX45FM9xa58Duh4T5xRvimCdeBBO8YazlbCmCfJXzipbgOQk6f8rWRa8IurY938cNH6eQ0kRrQxI9Hm2zBJ4tTZRafNfc63Pov2t6+B/nG7lDLshUmSZRvmhHQwLHIwJsKoQYjPqvgCaxN87KZae4INN0PdXcTthGrvAOO+BsS8sQq6oUPTADYBYoBK+ZUrqVFfG4PZxI9C59Z6HnzkoyN0rru5rPUWN7LYLjFN2jHXFL9r0wOrUXldAgwQxTWvjn5baf6dlD4jVRr91+PagO7MNbL+hvTSqvdtnWRSpSOTA3ghBXCNSf49VTOuEkt6JFdSvst9MPG0d4Su7aWkBFAshSlCrLOc1zJwD9ZAC3ETsvWDSXCn9s3UkYTp1xQb0ICzGUlGoNsB7313rqTg+8QJjok/6a3Wbdkn1oxWTcGw410dqKUqeIwVQ817ht2AXukOWJ3Qb6kwqA1y3PFE3+IgPq0AbI30Y5rBRUCgMDdPCYOGgpKLt36kb+4g4tdMNaeXRKv/Vc6HvcUgBrBJMTZ7nO1p+3Id7fsbAOwIgmzvA99JVjnIsrC3k4l6sQRYUzJYbc1YCSgAW9ilq11tA3nZW9fznTIZfS4YENHTr6LOxZ3fDBd1hadHwGgqaSa/N2BTDtrxhDqwjfSdnD6P2PsvPLWOgwvF6baa4B1QLHjvzxKJDflYA7D5cYAQ=="
+      },
+      {
+        "id": "toolu_01X1hqyFZcMP4pjx4QqJNvzt",
+        "type": "tool_use",
+        "name": "readfile",
+        "input": {
+          "path": "test/fixtures/red-circle.png"
+        }
+      }
+    ]
+  },
+  {
+    "role": "developer",
+    "content": [
+      {
+        "type": "tool_result",
+        "tool_use_id": "toolu_01X1hqyFZcMP4pjx4QqJNvzt",
+        "content": [
+          {
+            "type": "text",
+            "text": "Read image file [image/png]"
+          },
+          {
+            "type": "image",
+            "data": "iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAABmJLR0QA/wD/AP+gvaeTAAAJuklEQVR4nO3df2hV9R/H8deNLSl1a6Zs17S1pmsTolaUJdoPHJaU/RQ00DQK/4hIooIiI6J/FPpF/SdJ5ciMMDD7gThRyyChH5DR5kQXarU5N62c2lzs+8eHfZGwN3Ode9/3fs7zAUP/iPm+Oz33Ofecc8/JDA4ODgrAWZ3nPQBQyAgEMBAIYCAQwEAggIFAAAOBAAYCAQwEAhgIBDAQCGAgEMBAIICBQAADgQAGAgEMBAIYCAQwEAhgIBDAQCCAgUAAA4EABgIBDAQCGAgEMBAIYCAQwEAggIFAAAOBAAYCAQwEAhgIBDAQCGAgEMBAIICBQAADgQAGAgEMBAIYCAQwEAhgIBDAQCCAgUAAA4EABgIBDAQCGEq8B0iNnh5pzx6prU1qbw9/7+yU+vrC19Gj4U9JGj1aqqgIf44eLWWzUl1d+Kqvl664Qrr4Yt/XkxKZwcHBQe8hotTZKX35pdTSIm3ZInV0JPv9s1lp5kypqUm67TapujrZ7w9JBJKs1lZp7VppwwZp7978/tt1ddL8+dLixWGVQSII5L86ckRat05qbpa++cZ7muD666VFi6QHHpDGj/eepqgRyEgdOCC98or01lvSiRPe05zdqFHSkiXSihXS5Mne0xQlAjlXHR3S669Lq1dLp055TzM8paXSwoXSc8+FN/gYNgIZrr4+6aWXwqoxMOA9zciUlEiPPhpeR1mZ9zRFgUCGY9Om8D/WoUPekyQjm5VWrgxv6DMZ72kKGoFYOjqkhx+Wtm3zniQ3Zs+W1qzhELGBM+n/ZuNG6dpr441DkrZula66SvrwQ+9JChaB/NPp09Izz0j33hvObsfu99+lBQuk5cul/n7vaQoOu1hn+u036a67Cud8Rr5Nnx5WzspK70kKBoEM6egIl2zk+wx4oampkTZvlqZO9Z6kILCLJUm7d4frmtIehxR+UcyaJX3/vfckBYFAduwIcfz6q/ckhaOrS7rllnCxZcqlexfrhx+km2+Wjh3znqQwlZWFo3jXXOM9iZv0BrJvX1g5Oju9JylsEyZIO3eGq4VTKJ27WIcPS3PnEsdwdHen+meVvkD++ku64w7ekJ+L/fule+5J5XmS9AXy9NPpPc/xX+zaJT37rPcUeZeu9yCffBJOBKboJScqk5E++iisJimRnkAOHJAaG6XeXu9JiltFhfTtt+GEYgqkYxdrcFBaupQ4knD0qLRsmfcUeZOOQNati/uq3HxraZE++MB7iryIfxfrjz+khgbOlCetqirc46u83HuSnIp/BVmxgjhyobNTevFF7ylyLu4VZO/esHr8/bf3JHEqKQmrSG2t9yQ5E/cKsnIlceTSwIC0apX3FDkV7wpy8KA0ZUoqz/7mVWlpWKkj/Vx7vCvIqlXEkQ+nT0uvvuo9Rc7EuYJ0d4ffaCdPek+SDhdcEFbsCO84H+cK8v77xJFPJ09K69d7T5ETcQbS3Ow9QfpE+jOPbxertVWaNs17inRqa4vu3r/xrSBr13pPkF7vvec9QeLiW0Hq6vgwlJeGBumnn7ynSFRcgfzyizRpkvcU6XbokHTJJd5TJCauXaytW70nwPbt3hMkKq5AuKTdX2TbIK5drOrq8MlB+KmpCTd5iEQ8gRw5Eu7hBH89PdK4cd5TJCKeXaw9e7wnwJD2du8JEkMgSF5E24JAkLyItkU8gUS0rBc9AilAKb13bEHq6vKeIDHxBHL8uPcEGPLnn94TJCaeQCLaKEUvom1BIEheRNsinkDYxSocBAKkQzyBjBnjPQGGjB3rPUFi4gkkoo1S9CLaFgSC5EW0LeIJhF2swkEgBaiqynsCDKms9J4gMfEEEtntZopafb33BIkhECQvom1BIEheRNsino/c9vZGefPkosRHbgvQuHHRPqOiqNTURBOHFFMgknTrrd4TYPZs7wkSRSBIVmTbIJ73IFJ4mm1Et70sOplMuP1rNus9SWLiWkEmTozqCErRaWiIKg4ptkAk6b77vCdIr/nzvSdIXFy7WFK4uwmriA8eoFME6uqk667zniJ9brwxujikGAORpMWLvSdIn0h/5vHtYknhRtaXXsqTbvPlwgvDXfUjvJIhzhVk/HjpkUe8p0iPZcuijEOKdQWRwqPAamul/n7vSeI2apS0b1+055/iXEGk8KzCBx/0niJ+Dz0UbRxSzCuIFH6z1ddLAwPek8SptDTcqLqmxnuSnIl3BZHCLtZjj3lPEa/ly6OOQ4p9BZHCXf4aGsI1QkhONhtODJaVeU+SU3GvIFK4w8bLL3tPEZ833og+DikNK8iQpiaeo56UOXOkzZu9p8iL9ARy8KDU2Bg+DoqRq6iQvvtOuuwy70nyIv5drCGTJ0vvvBM+s4CRyWSkt99OTRxSmgKRpDvvDEdeMDJPPSXdfbf3FHmVnl2sIf390k03Sbt2eU9SXGbMkLZvD+c+UiR9gUhSd7c0a1ZUT2PNqdpa6auvorql6HClaxdryIQJ0mefRffx0JzIZqUtW1IZh5TWQCTp8svDocqLLvKepHCVlUmffhr92XJLegORpCuvlDZulMrLvScpPOXlIY7GRu9JXKXzPcg//fijdPvtXI4ypKpK+vxz6eqrvSdxRyBDOjpCJO3t3pP4Gtr1nDLFe5KCkO5drDPV1EhffCFNn+49iZ8ZM6SvvyaOMxDImSorpZ07pRdekM5L0Y8mk5Eef1zati0c4cP/sYv1bzZtkpYuDY9ViFl5ubRmjXT//d6TFKQU/Zo8R/PmhYvympq8J8mdOXOk3buJw0AglurqcJLs44/DxY6xmDhRevfd8GY8pteVAwQyHPPmhUPBTzwhlZR4TzNypaXSk0+GS2y4ocWw8B7kXP38s/Taa9Lq1dKpU97TDM/550sLFkjPPy9Nneo9TVEhkJHq6gqhvPmmdOKE9zRnN2qUtGRJCGPSJO9pihKB/Fc9PdL69VJzc+FcQn/DDeFeuQsXRvW8QA8EkqT29hDKhg1Sa2t+/+1p08LzORYtYjcqQQSSK4cPSzt2SC0t4Wv//mS/fzYrzZwZDkPPncvRqBwhkHzp7Q0rTFtbOIrU3i51dkp9feHeXceOScePh/92zJhwGf7YseHvlZXh2RtnflVU+L6elCAQwMB5EMBAIICBQAADgQAGAgEMBAIYCAQwEAhgIBDAQCCAgUAAA4EABgIBDAQCGAgEMBAIYCAQwEAggIFAAAOBAAYCAQwEAhgIBDAQCGAgEMBAIICBQAADgQAGAgEMBAIYCAQwEAhgIBDAQCCAgUAAA4EABgIBDAQCGAgEMBAIYCAQwEAggIFAAAOBAAYCAQwEAhgIBDAQCGAgEMDwP4yLqLwXdlfVAAAAAElFTkSuQmCC",
+            "media_type": "image/png"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "msg_01JJdAQ8sCHB7yHQuLMxGh4K",
+    "model": "claude-sonnet-4-20250514",
+    "usage": {
+      "input_tokens": 1526,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "output_tokens": 61,
+      "reasoning_tokens": 0
+    },
+    "role": "assistant",
+    "stop_reason": "stop",
+    "provider": "anthropic",
+    "api": "messages",
+    "content": [
+      {
+        "type": "text",
+        "text": "Based on reading the file, I can see that the image contains a simple red circle on a white background. The image appears to be a basic geometric shape - specifically a solid red circular shape centered in the frame. This matches what the filename \"red-circle.png\" suggests."
+      }
+    ]
+  }
+]

--- a/test/integration/handoff_live_test.rb
+++ b/test/integration/handoff_live_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "json"
+require_relative "../utils/live_test_helper"
+require_relative "../utils/calculator_tool_helper"
+
+class HandoffLiveTest < Test
+  include LiveTestHelper
+  include CalculatorToolHelper
+
+  FIXTURE_PATH = File.expand_path("../fixtures/handoff_live_fixture.json", __dir__)
+
+  PAIRS = [
+    { provider: "openai_apikey_completions", model: "gpt-5.1" },
+    { provider: "openai_apikey_responses", model: "gpt-5.4" },
+    { provider: "openai_oauth_codex", model: "gpt-5.4" },
+    { provider: "anthropic_apikey_messages", model: "claude-sonnet-4-20250514" }
+  ].freeze
+
+  def teardown
+    LlmGateway.reset_configuration!
+  end
+
+  def run_handoff_for(provider:, model:)
+    skip "Missing fixture at #{FIXTURE_PATH}. Run: ruby scripts/generate_handoff_live_fixture.rb" unless File.exist?(FIXTURE_PATH)
+
+    base_transcript = symbolize(JSON.parse(File.read(FIXTURE_PATH)))
+    transcript = Marshal.load(Marshal.dump(base_transcript))
+    transcript << { role: "user", content: "How many tool calls have you made" }
+
+    adapter = load_provider(provider:, model:)
+    response = adapter.stream(transcript, tools: [ math_operation_tool ], reasoning: "high")
+    refute_equal "error", response.stop_reason, "#{provider}/#{model} failed: #{response.error_message}"
+
+    has_text_with_four = response.content.any? do |block|
+      block.type == "text" && block.text.include?(PAIRS.length.to_s)
+    end
+    assert has_text_with_four, "#{provider}/#{model} expected a text block containing '4', got: #{response.content.map(&:to_h)}"
+  end
+
+  def self.define_handoff_test_for(provider:, model:)
+    test "#{provider}_#{model} handoff_live_test" do
+      skip_on_authentication_error do
+        without_vcr do
+          run_handoff_for(provider:, model:)
+        end
+      end
+    end
+  end
+
+  PAIRS.each do |pair|
+    define_handoff_test_for(provider: pair[:provider], model: pair[:model])
+  end
+
+  private
+
+  def symbolize(value)
+    case value
+    when Array
+      value.map { |item| symbolize(item) }
+    when Hash
+      value.each_with_object({}) { |(k, v), acc| acc[k.to_sym] = symbolize(v) }
+    else
+      value
+    end
+  end
+end

--- a/test/integration/handoff_media_live_test.rb
+++ b/test/integration/handoff_media_live_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "json"
+require_relative "../utils/live_test_helper"
+require_relative "../utils/readfile_tool_helper"
+
+class HandoffMediaLiveTest < Test
+  include LiveTestHelper
+  include ReadfileToolHelper
+
+  FIXTURE_PATH = File.expand_path("../fixtures/handoff_media_live_fixture.json", __dir__)
+
+  PAIRS = [
+    { provider: "openai_apikey_completions", model: "gpt-5.1" },
+    { provider: "openai_apikey_responses", model: "gpt-5.4" },
+    { provider: "openai_oauth_codex", model: "gpt-5.4" },
+    { provider: "anthropic_apikey_messages", model: "claude-sonnet-4-20250514" }
+  ].freeze
+
+  def teardown
+    LlmGateway.reset_configuration!
+  end
+
+  def run_handoff_for(provider:, model:)
+    skip "Missing fixture at #{FIXTURE_PATH}. Run: ruby scripts/generate_handoff_media_fixture.rb" unless File.exist?(FIXTURE_PATH)
+
+    base_transcript = symbolize(JSON.parse(File.read(FIXTURE_PATH)))
+    transcript = Marshal.load(Marshal.dump(base_transcript))
+    transcript << {
+      role: "user",
+      content: "What did you see, and how many times did you see it? Answer with an Arabic numeral for the count."
+    }
+
+    adapter = load_provider(provider:, model:)
+    response = adapter.stream(transcript, tools: [ readfile_tool ], reasoning: "high")
+    refute_equal "error", response.stop_reason, "#{provider}/#{model} failed: #{response.error_message}"
+
+    text = response.content.select { |block| block.type == "text" }.map(&:text).join(" ").downcase
+
+    assert_includes text, "red"
+    assert_includes text, "circle"
+    assert_includes text, PAIRS.length.to_s
+  end
+
+  def self.define_handoff_test_for(provider:, model:)
+    test "#{provider}_#{model} handoff_media_live_test" do
+      skip_on_authentication_error do
+        without_vcr do
+          run_handoff_for(provider:, model:)
+        end
+      end
+    end
+  end
+
+  PAIRS.each do |pair|
+    define_handoff_test_for(provider: pair[:provider], model: pair[:model])
+  end
+
+  private
+
+  def symbolize(value)
+    case value
+    when Array
+      value.map { |item| symbolize(item) }
+    when Hash
+      value.each_with_object({}) { |(k, v), acc| acc[k.to_sym] = symbolize(v) }
+    else
+      value
+    end
+  end
+end

--- a/test/unit/input_message_sanitizer_test.rb
+++ b/test/unit/input_message_sanitizer_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "../../lib/llm_gateway/adapters/input_message_sanitizer"
+
+class InputMessageSanitizerTest < Test
+  SANITIZER = LlmGateway::Adapters::InputMessageSanitizer
+
+  test "keeps thinking/reasoning blocks for same provider api and model" do
+    messages = [
+      {
+        role: "assistant",
+        provider: "openai",
+        api: "responses",
+        model: "gpt-5.4",
+        content: [ { type: "reasoning", reasoning: "private" } ]
+      }
+    ]
+
+    result = SANITIZER.sanitize(messages, target_provider: "openai", target_api: "responses", target_model: "gpt-5.4")
+    assert_equal "reasoning", result[0][:content][0][:type]
+  end
+
+  test "flattens thinking/reasoning to text for cross provider/api/model" do
+    messages = [
+      {
+        role: "assistant",
+        provider: "anthropic",
+        api: "messages",
+        model: "claude-sonnet-4",
+        content: [
+          { type: "thinking", thinking: "first thought" },
+          { type: "reasoning", summary: [ { text: "second thought" } ] }
+        ]
+      }
+    ]
+
+    result = SANITIZER.sanitize(messages, target_provider: "openai", target_api: "responses", target_model: "gpt-5.4")
+
+    assert_equal [ "text", "text" ], result[0][:content].map { |block| block[:type] }
+    assert_equal [ "first thought", "second thought" ], result[0][:content].map { |block| block[:text] }
+  end
+
+  test "does not sanitize assistant reasoning when message metadata is missing" do
+    messages = [
+      {
+        role: "assistant",
+        content: [ { type: "reasoning", reasoning: "private" } ]
+      }
+    ]
+
+    result = SANITIZER.sanitize(messages, target_provider: "openai", target_api: "responses", target_model: "gpt-5.4")
+
+    assert_equal "reasoning", result[0][:content][0][:type]
+    assert_equal "private", result[0][:content][0][:reasoning]
+  end
+end

--- a/test/unit/openai_chat_completions_input_message_sanitizer_test.rb
+++ b/test/unit/openai_chat_completions_input_message_sanitizer_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "../../lib/llm_gateway/adapters/open_ai/chat_completions/input_message_sanitizer"
+
+class OpenAiChatCompletionsInputMessageSanitizerTest < Test
+  SANITIZER = LlmGateway::Adapters::OpenAi::ChatCompletions::InputMessageSanitizer
+
+  test "normalizes responses-style tool_use id and corresponding tool_result reference" do
+    source_id = "call:abc/123|item_999"
+    messages = [
+      {
+        role: "assistant",
+        content: [ { type: "tool_use", id: source_id, name: "math", input: { a: 1 } } ]
+      },
+      {
+        role: "developer",
+        content: [ { type: "tool_result", tool_use_id: source_id, content: "ok" } ]
+      }
+    ]
+
+    result = SANITIZER.sanitize(messages, target_provider: "openai", target_api: "completions", target_model: "gpt-5.1")
+
+    expected = "call_abc_123"
+    assert_equal expected, result[0][:content][0][:id]
+    assert_equal expected, result[1][:content][0][:tool_use_id]
+  end
+
+  test "truncates tool_use id to 40 chars when target provider is openai" do
+    long_id = "x" * 60
+    messages = [
+      {
+        role: "assistant",
+        content: [ { type: "tool_use", id: long_id, name: "math", input: {} } ]
+      }
+    ]
+
+    result = SANITIZER.sanitize(messages, target_provider: "openai", target_api: "completions", target_model: "gpt-5.1")
+    assert_equal 40, result[0][:content][0][:id].length
+    assert_equal "x" * 40, result[0][:content][0][:id]
+  end
+
+  test "keeps tool_use id as-is for non-openai target provider when id has no pipe" do
+    long_id = "z" * 60
+    messages = [
+      {
+        role: "assistant",
+        content: [ { type: "tool_use", id: long_id, name: "math", input: {} } ]
+      }
+    ]
+
+    result = SANITIZER.sanitize(messages, target_provider: "groq", target_api: "completions", target_model: "llama-3.3")
+    assert_equal long_id, result[0][:content][0][:id]
+  end
+end

--- a/test/utils/readfile_tool_helper.rb
+++ b/test/utils/readfile_tool_helper.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "base64"
+
+module ReadfileToolHelper
+  def readfile_tool
+    {
+      name: "readfile",
+      description: "Reads a file and returns its contents",
+      input_schema: {
+        type: "object",
+        properties: {
+          path: { type: "string", description: "Path to a file" }
+        },
+        required: [ "path" ]
+      }
+    }
+  end
+
+  def evaluate_readfile(input)
+    path = input[:path] || input["path"]
+    full_path = File.expand_path("../fixtures/red-circle.png", __dir__)
+
+    raise "Unsupported path: #{path}" unless path == "test/fixtures/red-circle.png"
+
+    image_data = Base64.strict_encode64(File.binread(full_path))
+    [
+      { type: "text", text: "Read image file [image/png]" },
+      { type: "image", data: image_data, media_type: "image/png" }
+    ]
+  end
+end


### PR DESCRIPTION
 #### 1) Every adapter can now sanitize input messages before mapping

 In lib/llm_gateway/adapters/adapter.rb:

 - input_sanitizer was added to adapter initialization.
 - In both chat and stream, messages now go through:
 - normalize → sanitize → input_mapper

 So cross-provider handoff happens at request time, right before provider-specific input mapping.


 #### 2) Generic sanitizer handles reasoning/thinking portability

 New file: lib/llm_gateway/adapters/input_message_sanitizer.rb

 For assistant messages with metadata (provider, api, model):

 - If replaying to the same provider/api/model: keep thinking/reasoning blocks unchanged.
 - If replaying to a different provider/api/model:
     - convert thinking / reasoning blocks into normal { type: "text", text: ... }
     - drop empty reasoning text

 This prevents provider-specific reasoning block formats from breaking on another provider.



 #### 3) OpenAI chat-completions adds tool-call ID normalization

 New file: lib/llm_gateway/adapters/open_ai/chat_completions/input_message_sanitizer.rb

 On top of generic sanitizing, it normalizes tool IDs:

 - tool_use/function IDs are cleaned/truncated (40 chars for OpenAI target)
 - linked tool_result.tool_use_id is updated to match

 This keeps tool-call/result references valid when handing off transcripts between APIs/providers with different ID constraints.
