### PR TITLE
test(feat): allow options to be passed in model pairs

### DIFF
--- a/test/integration/live/cache_test.rb
+++ b/test/integration/live/cache_test.rb
@@ -8,6 +8,69 @@ require_relative "../../utils/live_test_helper"
 class CacheLiveTest < Test
   include LiveTestHelper
 
+  PAIRS = [
+    {
+      name: "openai_apikey_completions",
+      provider: "openai_apikey_completions",
+      model: "gpt-5.1",
+      options: {
+        cache_key: "openai_apikey_completions",
+        cache_retention: "short"
+      }
+    },
+    {
+      name: "openai_apikey_completions_none",
+      provider: "openai_apikey_completions",
+      model: "gpt-5.1",
+      options: {
+        cache_key: "openai_apikey_completions_none",
+        cache_retention: "none"
+      }
+    },
+    {
+      name: "openai_apikey_responses",
+      provider: "openai_apikey_responses",
+      model: "gpt-5.4",
+      options: {
+        cache_key: "openai_apikey_responses",
+        cache_retention: "short"
+      }
+    },
+    {
+      name: "openai_apikey_responses_none",
+      provider: "openai_apikey_responses",
+      model: "gpt-5.4",
+      options: {
+        cache_key: "openai_apikey_responses_none",
+        cache_retention: "none"
+      }
+    },
+    {
+      name: "openai_oauth_codex",
+      provider: "openai_oauth_codex",
+      model: "gpt-5.4",
+      options: {
+        cache_key: "openai_oauth_codex"
+      }
+    },
+    {
+      name: "anthropic_apikey_messages",
+      provider: "anthropic_apikey_messages",
+      model: "claude-sonnet-4-20250514",
+      options: {
+        cache_retention: "short"
+      }
+    },
+    {
+      name: "anthropic_apikey_messages_none",
+      provider: "anthropic_apikey_messages",
+      model: "claude-sonnet-4-20250514",
+      options: {
+        cache_retention: "none"
+      }
+    }
+  ].freeze
+
   DOCUMENT_URL = "https://gist.githubusercontent.com/billybonks/f343b02cc67535475b8819d281763c21/raw/c55972e604ecc9b5b998ed44d9e9575cebaf2fc8/responses.md"
 
   def teardown
@@ -81,70 +144,12 @@ class CacheLiveTest < Test
     end
   end
 
-  define_cache_tests_for(
-    name: "openai_apikey_completions",
-    provider: "openai_apikey_completions",
-    model: "gpt-5.1",
-    options: {
-      cache_key: "openai_apikey_completions",
-      cache_retention: "short"
-    }
-  )
-
-  define_cache_tests_for(
-    name: "openai_apikey_completions_none",
-    provider: "openai_apikey_completions",
-    model: "gpt-5.1",
-    options: {
-      cache_key: "openai_apikey_completions_none",
-      cache_retention: "none"
-    }
-  )
-
-  define_cache_tests_for(
-    name: "openai_apikey_responses",
-    provider: "openai_apikey_responses",
-    model: "gpt-5.4",
-    options: {
-      cache_key: "openai_apikey_responses",
-      cache_retention: "short"
-    }
-  )
-
-  define_cache_tests_for(
-    name: "openai_apikey_responses_none",
-    provider: "openai_apikey_responses",
-    model: "gpt-5.4",
-    options: {
-      cache_key: "openai_apikey_responses_none",
-      cache_retention: "none"
-    }
-  )
-
-  define_cache_tests_for(
-    name: "openai_oauth_codex",
-    provider: "openai_oauth_codex",
-    model: "gpt-5.4",
-    options: {
-      cache_key: "openai_oauth_codex"
-    }
-  )
-
-  define_cache_tests_for(
-    name: "anthropic_apikey_messages",
-    provider: "anthropic_apikey_messages",
-    model: "claude-sonnet-4-20250514",
-    options: {
-      cache_retention: "short"
-    }
-  )
-
-  define_cache_tests_for(
-    name: "anthropic_apikey_messages_none",
-    provider: "anthropic_apikey_messages",
-    model: "claude-sonnet-4-20250514",
-    options: {
-      cache_retention: "none"
-    }
-  )
+  PAIRS.each do |pair|
+    define_cache_tests_for(
+      name: pair[:name],
+      provider: pair[:provider],
+      model: pair[:model],
+      options: pair[:options]
+    )
+  end
 end

--- a/test/integration/live/prompt_too_long_test.rb
+++ b/test/integration/live/prompt_too_long_test.rb
@@ -6,6 +6,14 @@ require_relative "../../utils/live_test_helper"
 class PromptTooLongLiveTest < Test
   include LiveTestHelper
 
+  PAIRS = [
+    { provider: "openai_apikey_completions", model: "gpt-5.1" },
+    { provider: "anthropic_apikey_messages", model: "claude-sonnet-4-20250514" },
+    { provider: "openai_apikey_responses", model: "gpt-5.4" },
+    { provider: "anthropic_oauth_messages", model: "claude-sonnet-4-20250514" },
+    { provider: "openai_oauth_codex", model: "gpt-5.4" }
+  ].freeze
+
   def teardown
     LlmGateway.reset_configuration!
   end
@@ -14,45 +22,24 @@ class PromptTooLongLiveTest < Test
     "Please reply with one short sentence.\n\n" + ("lorem ipsum dolor sit amet " * 240_000)
   end
 
-  def assert_prompt_too_long(adapter, provider)
+  def assert_prompt_too_long(adapter, provider, options: {})
     error = assert_raises(LlmGateway::Errors::PromptTooLong) do
-      adapter.stream(huge_prompt)
+      adapter.stream(huge_prompt, **options)
     end
 
     assert LlmGateway::Errors.context_overflow_message?(error.message),
       "Expected prompt-length related error message for #{provider}, got: #{error.message}"
   end
 
-  def self.define_prompt_too_long_debug_test(provider:, model:)
+  def self.define_prompt_too_long_debug_test(provider:, model:, options: {})
     test "live_prompt_too_long_#{provider}_#{model}" do
       with_vcr_adapter(provider:, model:, redact_request_body: true) do |adapter|
-        assert_prompt_too_long(adapter, provider)
+        assert_prompt_too_long(adapter, provider, options: options)
       end
     end
   end
 
-  define_prompt_too_long_debug_test(
-    provider: "openai_apikey_completions",
-    model: "gpt-5.1"
-  )
-
-  define_prompt_too_long_debug_test(
-    provider: "anthropic_apikey_messages",
-    model: "claude-sonnet-4-20250514"
-  )
-
-  define_prompt_too_long_debug_test(
-    provider: "openai_apikey_responses",
-    model: "gpt-5.4"
-  )
-
-  define_prompt_too_long_debug_test(
-    provider: "anthropic_oauth_messages",
-    model: "claude-sonnet-4-20250514"
-  )
-
-  define_prompt_too_long_debug_test(
-    provider: "openai_oauth_codex",
-    model: "gpt-5.4"
-  )
+  PAIRS.each do |pair|
+    define_prompt_too_long_debug_test(provider: pair[:provider], model: pair[:model], options: pair.fetch(:options, {}))
+  end
 end

--- a/test/integration/live/stream_image_test.rb
+++ b/test/integration/live/stream_image_test.rb
@@ -20,7 +20,7 @@ class StreamImageTest < Test
     LlmGateway.reset_configuration!
   end
 
-  def basic_image_streaming_test(adapter)
+  def basic_image_streaming_test(adapter, options: {})
     image_path = File.expand_path("../../fixtures/red-circle.png", __dir__)
     image_data = Base64.strict_encode64(File.binread(image_path))
 
@@ -41,7 +41,7 @@ class StreamImageTest < Test
       }
     ]
 
-    response = adapter.stream(prompt, system: "You are a helpful assistant.")
+    response = adapter.stream(prompt, system: "You are a helpful assistant.", **options)
 
     assert_equal "assistant", response.role
     assert_operator response.usage[:input_tokens], :>, 0
@@ -58,16 +58,16 @@ class StreamImageTest < Test
     response
   end
 
-  def self.define_stream_image_tests_for(provider:, model:)
+  def self.define_stream_image_tests_for(provider:, model:, options: {})
     test "live_image_streaming_#{provider}_#{model}" do
       with_vcr_adapter(provider:, model:) do |adapter|
-        response = basic_image_streaming_test(adapter)
+        response = basic_image_streaming_test(adapter, options: options)
         record_live_handoff_result(test_file: __FILE__, provider:, model:, result: response)
       end
     end
   end
 
   PAIRS.each do |pair|
-    define_stream_image_tests_for(provider: pair[:provider], model: pair[:model])
+    define_stream_image_tests_for(provider: pair[:provider], model: pair[:model], options: pair.fetch(:options, {}))
   end
 end

--- a/test/integration/live/stream_reasoning_test.rb
+++ b/test/integration/live/stream_reasoning_test.rb
@@ -19,12 +19,12 @@ class StreamReasoningTest < Test
     LlmGateway.reset_configuration!
   end
 
-  def basic_thinking_test(adapter, reasoning: "high")
+  def basic_thinking_test(adapter, reasoning: "high", options: {})
     prompt = "Think long and hard about 42 + 27"
     thinking_started = false
     thinking_chunks = ""
     thinking_completed = false
-    response = adapter.stream(prompt, reasoning:,) do |event|
+    response = adapter.stream(prompt, reasoning:, **options) do |event|
       case event.type
       when :reasoning_start
         thinking_started = true
@@ -57,16 +57,16 @@ class StreamReasoningTest < Test
     response
   end
 
-  def self.define_stream_reasoning_tests_for(provider:, model:)
+  def self.define_stream_reasoning_tests_for(provider:, model:, options: {})
     test "live_basic_thinking_#{provider}_#{model}" do
       with_vcr_adapter(provider:, model:) do |adapter|
-        response = basic_thinking_test(adapter, reasoning: "high")
+        response = basic_thinking_test(adapter, reasoning: "high", options: options)
         record_live_handoff_result(test_file: __FILE__, provider:, model:, result: response)
       end
     end
   end
 
   PAIRS.each do |pair|
-    define_stream_reasoning_tests_for(provider: pair[:provider], model: pair[:model])
+    define_stream_reasoning_tests_for(provider: pair[:provider], model: pair[:model], options: pair.fetch(:options, {}))
   end
 end

--- a/test/integration/live/stream_text_test.rb
+++ b/test/integration/live/stream_text_test.rb
@@ -19,12 +19,12 @@ class StreamTextTest < Test
     LlmGateway.reset_configuration!
   end
 
-  def basic_streaming_text_test(adapter)
+  def basic_streaming_text_test(adapter, options: {})
     text_started = false
     text_chunks = ""
     text_completed = false
 
-    response = adapter.stream("Count from 1 to 3") do |event|
+    response = adapter.stream("Count from 1 to 3", **options) do |event|
       case event.type
       when :text_start
         text_started = true
@@ -45,16 +45,16 @@ class StreamTextTest < Test
     response
   end
 
-  def self.define_stream_tests_for(provider:, model:)
+  def self.define_stream_tests_for(provider:, model:, options: {})
     test "live_text_streaming_#{provider}_#{model}" do
       with_vcr_adapter(provider:, model:) do |adapter|
-        response = basic_streaming_text_test(adapter)
+        response = basic_streaming_text_test(adapter, options: options)
         record_live_handoff_result(test_file: __FILE__, provider:, model:, result: response)
       end
     end
   end
 
   PAIRS.each do |pair|
-    define_stream_tests_for(provider: pair[:provider], model: pair[:model])
+    define_stream_tests_for(provider: pair[:provider], model: pair[:model], options: pair.fetch(:options, {}))
   end
 end

--- a/test/integration/live/stream_tool_call_test.rb
+++ b/test/integration/live/stream_tool_call_test.rb
@@ -22,13 +22,13 @@ class StreamToolCallTest < Test
     LlmGateway.reset_configuration!
   end
 
-  def basic_tool_call(adapter)
+  def basic_tool_call(adapter, options: {})
     prompt = "Calculate 15 + 27 using the math_operation tool"
     accumulated_tool_args = ""
     has_tool_start = false
     has_tool_delta = false
     has_tool_end = false
-    response = adapter.stream(prompt, tools: [ math_operation_tool ]) do |event|
+    response = adapter.stream(prompt, tools: [ math_operation_tool ], **options) do |event|
       if event.type == :tool_start
         has_tool_start = true
         assert_equal "math_operation", event.name
@@ -68,16 +68,16 @@ class StreamToolCallTest < Test
     response
   end
 
-  def self.define_stream_tests_for(provider:, model:)
+  def self.define_stream_tests_for(provider:, model:, options: {})
     test "live_basic_tool_call_#{provider}_#{model}" do
       with_vcr_adapter(provider:, model:) do |adapter|
-        response = basic_tool_call(adapter)
+        response = basic_tool_call(adapter, options: options)
         record_live_handoff_result(test_file: __FILE__, provider:, model:, result: response)
       end
     end
   end
 
   PAIRS.each do |pair|
-    define_stream_tests_for(provider: pair[:provider], model: pair[:model])
+    define_stream_tests_for(provider: pair[:provider], model: pair[:model], options: pair.fetch(:options, {}))
   end
 end


### PR DESCRIPTION
# Goal
Allow live provider model pair tests to pass request options so individual provider/model requirements can be tuned during test runs.

# Changes made to achieve the goal
Updates the testing framework to support options in model pairs and aligns cache and prompt-too-long live tests with the broader live test structure.

> read the commit messages for more details
