### PR TITLE
burn: support for legacy provider keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ If you only care about the final `AssistantMessage`, call `stream` without a blo
 require "llm_gateway"
 
 adapter = LlmGateway.build_provider(
-  provider: "openai_apikey_responses",
+  provider: "openai_responses",
   api_key: ENV.fetch("OPENAI_API_KEY"),
   model_key: "gpt-5.4"
 )
@@ -228,7 +228,7 @@ require "llm_gateway"
 require "json"
 
 adapter = LlmGateway.build_provider(
-  provider: "openai_apikey_responses",
+  provider: "openai_responses",
   api_key: ENV.fetch("OPENAI_API_KEY"),
   model_key: "gpt-5.4"
 )
@@ -309,7 +309,7 @@ require "llm_gateway"
 require "base64"
 
 adapter = LlmGateway.build_provider(
-  provider: "openai_apikey_responses",
+  provider: "openai_responses",
   api_key: ENV.fetch("OPENAI_API_KEY"),
   model_key: "gpt-5.4"
 )
@@ -346,7 +346,7 @@ You can request higher-effort reasoning by passing `reasoning:` to `stream`.
 require "llm_gateway"
 
 adapter = LlmGateway.build_provider(
-  provider: "openai_apikey_responses",
+  provider: "openai_responses",
   api_key: ENV.fetch("OPENAI_API_KEY"),
   model_key: "gpt-5.4"
 )
@@ -455,7 +455,7 @@ require "llm_gateway"
 require "json"
 
 adapter = LlmGateway.build_provider(
-  provider: "openai_apikey_responses",
+  provider: "openai_responses",
   api_key: ENV.fetch("OPENAI_API_KEY"),
   model_key: "gpt-5.4"
 )
@@ -491,7 +491,7 @@ Tip: if you serialize to JSON, keys become strings on parse; `llm_gateway` accep
 
 ## OAuth
 
-Use OAuth-capable providers (for example `openai_codex` and `anthropic_oauth_messages`) by supplying an `access_token` when building the adapter.
+Use OAuth-capable providers (for example `openai_codex` and `anthropic_messages`) by supplying an `access_token` when building the adapter.
 
 ### Get initial tokens (Codex / OpenAI OAuth)
 
@@ -641,6 +641,6 @@ bundle exec ruby -Itest test/integration/live/stream_test.rb
 
 Cassette names are derived from the test file and test name, with VCR sanitizing path segments such as `stream_test.rb` to `stream_test_rb`.
 
-For OAuth-backed providers (`anthropic_oauth_messages`, `openai_oauth_codex`), the live test helper only loads real OAuth credentials while the cassette is being recorded. Once the cassette exists, replay uses placeholder tokens/account IDs so the test suite can run without local OAuth state. API-key providers still require the relevant API key when recording. Sensitive authorization headers and selected response headers are redacted before cassettes are written.
+For OAuth-backed providers (`anthropic_messages`, `openai_codex`), the live test helper only loads real OAuth credentials while the cassette is being recorded. Once the cassette exists, replay uses placeholder tokens/account IDs so the test suite can run without local OAuth state. API-key providers still require the relevant API key when recording. Sensitive authorization headers and selected response headers are redacted before cassettes are written.
 
 Some tests pass `redact_request_body: true` to `with_vcr_adapter`; those cassettes match on method and URI only and replace large request bodies with `"<huge prompt body redacted>"`.

--- a/lib/llm_gateway.rb
+++ b/lib/llm_gateway.rb
@@ -153,25 +153,4 @@ module LlmGateway
   ProviderRegistry.register("openai_codex",
     client: Clients::OpenAI,
     adapter: Adapters::OpenAICodex::ResponsesAdapter)
-
-  # Backward-compatible aliases (deprecated)
-  ProviderRegistry.register("anthropic_apikey_messages",
-    client: Clients::Anthropic,
-    adapter: Adapters::Anthropic::MessagesAdapter)
-
-  ProviderRegistry.register("openai_apikey_completions",
-    client: Clients::OpenAI,
-    adapter: Adapters::OpenAI::ChatCompletionsAdapter)
-
-  ProviderRegistry.register("openai_apikey_responses",
-    client: Clients::OpenAI,
-    adapter: Adapters::OpenAI::ResponsesAdapter)
-
-  ProviderRegistry.register("groq_apikey_completions",
-    client: Clients::Groq,
-    adapter: Adapters::Groq::ChatCompletionsAdapter)
-
-  ProviderRegistry.register("openai_oauth_codex",
-    client: Clients::OpenAI,
-    adapter: Adapters::OpenAICodex::ResponsesAdapter)
 end

--- a/test/client_builder_test.rb
+++ b/test/client_builder_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 class ClientBuilderTest < Test
   test "builds claude client with api key messages provider" do
     adapter = LlmGateway.build_provider({
-      provider: "anthropic_apikey_messages",
+      provider: "anthropic_messages",
       api_key: "sk-ant-test-key"
     })
 
@@ -15,7 +15,7 @@ class ClientBuilderTest < Test
 
   test "builds claude client with anthropic messages provider" do
     adapter = LlmGateway.build_provider({
-      provider: "anthropic_apikey_messages",
+      provider: "anthropic_messages",
       api_key: "sk-ant-oat-test-token"
     })
 
@@ -25,7 +25,7 @@ class ClientBuilderTest < Test
 
   test "builds openai client with default completions adapter" do
     adapter = LlmGateway.build_provider({
-      provider: "openai_apikey_completions",
+      provider: "openai_completions",
       api_key: "sk-openai-test-key"
     })
 
@@ -35,7 +35,7 @@ class ClientBuilderTest < Test
 
   test "builds openai client with responses api" do
     adapter = LlmGateway.build_provider({
-      provider: "openai_apikey_responses",
+      provider: "openai_responses",
       api_key: "sk-openai-test-key"
     })
 
@@ -45,7 +45,7 @@ class ClientBuilderTest < Test
 
   test "builds groq client" do
     adapter = LlmGateway.build_provider({
-      provider: "groq_apikey_completions",
+      provider: "groq_completions",
       api_key: "gsk-test-key"
     })
 
@@ -64,7 +64,7 @@ class ClientBuilderTest < Test
 
   test "works with string keys" do
     adapter = LlmGateway.build_provider({
-      "provider" => "groq_apikey_completions",
+      "provider" => "groq_completions",
       "api_key" => "gsk-test-key"
     })
 
@@ -73,9 +73,10 @@ class ClientBuilderTest < Test
   end
 
   test "provider registry exposes built in providers" do
-    assert LlmGateway::ProviderRegistry.registered?("anthropic_apikey_messages")
-    assert LlmGateway::ProviderRegistry.registered?("openai_apikey_completions")
-    assert LlmGateway::ProviderRegistry.registered?("openai_apikey_responses")
-    assert LlmGateway::ProviderRegistry.registered?("groq_apikey_completions")
+    assert LlmGateway::ProviderRegistry.registered?("anthropic_messages")
+    assert LlmGateway::ProviderRegistry.registered?("openai_completions")
+    assert LlmGateway::ProviderRegistry.registered?("openai_responses")
+    assert LlmGateway::ProviderRegistry.registered?("groq_completions")
+    assert LlmGateway::ProviderRegistry.registered?("openai_codex")
   end
 end

--- a/test/configure_test.rb
+++ b/test/configure_test.rb
@@ -12,14 +12,14 @@ class ConfigureTest < Test
       {
         name: "anthropic_sonnet",
         config: {
-          provider: "anthropic_apikey_messages",
+          provider: "anthropic_messages",
           api_key: "sk-ant-test-key"
         }
       },
       {
         name: "groq",
         config: {
-          provider: "groq_apikey_completions",
+          provider: "groq_completions",
           api_key: "gsk-test-key"
         }
       }
@@ -36,7 +36,7 @@ class ConfigureTest < Test
       {
         name: "my_openai",
         config: {
-          provider: "openai_apikey_completions",
+          provider: "openai_completions",
           api_key: "sk-openai-test-key"
         }
       }
@@ -49,7 +49,7 @@ class ConfigureTest < Test
   test "raises error when name is missing" do
     assert_raises(ArgumentError) do
       LlmGateway.configure([
-        { config: { provider: "groq_apikey_completions", api_key: "gsk-test-key" } }
+        { config: { provider: "groq_completions", api_key: "gsk-test-key" } }
       ])
     end
   end
@@ -59,7 +59,7 @@ class ConfigureTest < Test
       {
         name: "temp_client",
         config: {
-          provider: "groq_apikey_completions",
+          provider: "groq_completions",
           api_key: "gsk-test-key"
         }
       }
@@ -78,7 +78,7 @@ class ConfigureTest < Test
       {
         "name" => "string_key_client",
         "config" => {
-          "provider" => "groq_apikey_completions",
+          "provider" => "groq_completions",
           "api_key" => "gsk-test-key"
         }
       }

--- a/test/integration/live/cache_test.rb
+++ b/test/integration/live/cache_test.rb
@@ -11,7 +11,7 @@ class CacheLiveTest < Test
   PAIRS = [
     {
       name: "openai_apikey_completions",
-      provider: "openai_apikey_completions",
+      provider: "openai_completions",
       model: "gpt-5.1",
       options: {
         cache_key: "openai_apikey_completions",
@@ -20,7 +20,7 @@ class CacheLiveTest < Test
     },
     {
       name: "openai_apikey_completions_none",
-      provider: "openai_apikey_completions",
+      provider: "openai_completions",
       model: "gpt-5.1",
       options: {
         cache_key: "openai_apikey_completions_none",
@@ -29,7 +29,7 @@ class CacheLiveTest < Test
     },
     {
       name: "openai_apikey_responses",
-      provider: "openai_apikey_responses",
+      provider: "openai_responses",
       model: "gpt-5.4",
       options: {
         cache_key: "openai_apikey_responses",
@@ -38,7 +38,7 @@ class CacheLiveTest < Test
     },
     {
       name: "openai_apikey_responses_none",
-      provider: "openai_apikey_responses",
+      provider: "openai_responses",
       model: "gpt-5.4",
       options: {
         cache_key: "openai_apikey_responses_none",
@@ -47,7 +47,7 @@ class CacheLiveTest < Test
     },
     {
       name: "openai_oauth_codex",
-      provider: "openai_oauth_codex",
+      provider: "openai_codex",
       model: "gpt-5.4",
       options: {
         cache_key: "openai_oauth_codex"
@@ -55,7 +55,7 @@ class CacheLiveTest < Test
     },
     {
       name: "anthropic_apikey_messages",
-      provider: "anthropic_apikey_messages",
+      provider: "anthropic_messages",
       model: "claude-sonnet-4-20250514",
       options: {
         cache_retention: "short"
@@ -63,7 +63,7 @@ class CacheLiveTest < Test
     },
     {
       name: "anthropic_apikey_messages_none",
-      provider: "anthropic_apikey_messages",
+      provider: "anthropic_messages",
       model: "claude-sonnet-4-20250514",
       options: {
         cache_retention: "none"
@@ -140,9 +140,9 @@ class CacheLiveTest < Test
       "Expected cache_read_input_tokens to be 0 with options #{options.inspect}, got #{second_response.usage.inspect}"
   end
 
-  def self.define_cache_tests_for(name:, provider:, model:, options: {})
-    test "live_cache_read_tokens_on_second_turn_#{name}_#{provider}_#{model}" do
-      with_vcr_adapter(provider:, model:, redact_request_body: true) do |adapter|
+  def self.define_cache_tests_for(name:, provider:, cassette_provider:, model:, oauth:, options: {})
+    test "live_cache_read_tokens_on_second_turn_#{name}_#{cassette_provider}_#{model}" do
+      with_vcr_adapter(provider:, model:, redact_request_body: true, oauth:,) do |adapter|
         if provider.start_with?("anthropic") && options[:cache_retention].to_s == "none"
           assert_no_cache_hit_on_second_turn(adapter, options: options)
         else
@@ -156,7 +156,9 @@ class CacheLiveTest < Test
     define_cache_tests_for(
       name: pair[:name],
       provider: pair[:provider],
+      cassette_provider: pair[:name].sub(/_none\z/, ""),
       model: pair[:model],
+      oauth: pair[:oauth],
       options: pair[:options]
     )
   end

--- a/test/integration/live/handoff_stream_image_test.rb
+++ b/test/integration/live/handoff_stream_image_test.rb
@@ -16,7 +16,7 @@ class HandoffStreamImageLiveTest < Test
     LlmGateway.reset_configuration!
   end
 
-  def run_handoff_stream_image_for(provider:, model:, adapter:, options: {})
+  def run_handoff_stream_image_for(provider_name:, model:, adapter:, options: {})
     records = load_recorded_outputs
 
     prompt = <<~PROMPT
@@ -29,7 +29,7 @@ class HandoffStreamImageLiveTest < Test
     PROMPT
 
     response = adapter.stream(prompt, reasoning: "high", **options)
-    refute_equal "error", response.stop_reason, "#{provider}/#{model} failed: #{response.error_message}"
+    refute_equal "error", response.stop_reason, "#{provider_name}/#{model} failed: #{response.error_message}"
 
     text = response.content.select { |block| block.type == "text" }.map(&:text).join(" ").downcase
     assert_includes text, "red"
@@ -39,16 +39,16 @@ class HandoffStreamImageLiveTest < Test
     assert text.include?(expected_count) || text.include?(arabic_indic_count), "Expected #{text.inspect} to include #{expected_count.inspect} or #{arabic_indic_count.inspect}"
   end
 
-  def self.define_handoff_stream_image_test_for(provider:, model:, options: {})
-    test "handoff_stream_image__#{provider}_#{model}" do
-      with_vcr_adapter(provider:, model:) do |adapter|
-        run_handoff_stream_image_for(provider:, model:, adapter:, options:)
+  def self.define_handoff_stream_image_test_for(provider_name:, provider:, model:, oauth:, options: {})
+    test "handoff_stream_image__#{provider_name}_#{model}" do
+      with_vcr_adapter(provider:, model:, oauth:) do |adapter|
+        run_handoff_stream_image_for(provider_name:, model:, adapter:, options:)
       end
     end
   end
 
   PAIRS.each do |pair|
-    define_handoff_stream_image_test_for(provider: pair[:provider], model: pair[:model], options: pair.fetch(:options, {}))
+    define_handoff_stream_image_test_for(provider_name: pair[:name], provider: pair[:provider], model: pair[:model], oauth: pair[:oauth], options: pair.fetch(:options, {}))
   end
 
   private

--- a/test/integration/live/handoff_stream_reasoning_test.rb
+++ b/test/integration/live/handoff_stream_reasoning_test.rb
@@ -16,7 +16,7 @@ class HandoffStreamReasoningLiveTest < Test
     LlmGateway.reset_configuration!
   end
 
-  def run_handoff_stream_reasoning_for(provider:, model:, adapter:)
+  def run_handoff_stream_reasoning_for(provider_name:, model:, adapter:, options: {})
     records = load_recorded_outputs
 
     prompt = <<~PROMPT
@@ -27,24 +27,24 @@ class HandoffStreamReasoningLiveTest < Test
       #{JSON.pretty_generate(records)}
     PROMPT
 
-    response = adapter.stream(prompt, reasoning: "high")
-    refute_equal "error", response.stop_reason, "#{provider}/#{model} failed: #{response.error_message}"
+    response = adapter.stream(prompt, reasoning: "high", **options)
+    refute_equal "error", response.stop_reason, "#{provider_name}/#{model} failed: #{response.error_message}"
 
     text = response.content.select { |block| block.type == "text" }.map(&:text).join(" ").downcase
     assert_includes text, "69"
     assert_includes text, records.length.to_s
   end
 
-  def self.define_handoff_stream_reasoning_test_for(provider:, model:)
-    test "handoff_stream_reasoning__#{provider}_#{model}" do
-      with_vcr_adapter(provider:, model:) do |adapter|
-        run_handoff_stream_reasoning_for(provider:, model:, adapter:)
+  def self.define_handoff_stream_reasoning_test_for(provider_name:, provider:, model:, oauth:, options: {})
+    test "handoff_stream_reasoning__#{provider_name}_#{model}" do
+      with_vcr_adapter(provider:, model:, oauth:) do |adapter|
+        run_handoff_stream_reasoning_for(provider_name:, model:, adapter:, options:)
       end
     end
   end
 
   PAIRS.each do |pair|
-    define_handoff_stream_reasoning_test_for(provider: pair[:provider], model: pair[:model])
+    define_handoff_stream_reasoning_test_for(provider_name: pair[:name], provider: pair[:provider], model: pair[:model], oauth: pair[:oauth], options: pair.fetch(:options, {}))
   end
 
   private

--- a/test/integration/live/handoff_stream_text_test.rb
+++ b/test/integration/live/handoff_stream_text_test.rb
@@ -16,7 +16,7 @@ class HandoffStreamTextLiveTest < Test
     LlmGateway.reset_configuration!
   end
 
-  def run_handoff_stream_for(provider:, model:, adapter:)
+  def run_handoff_stream_for(provider_name:, model:, adapter:, options: {})
     records = load_recorded_outputs
 
     prompt = <<~PROMPT
@@ -27,8 +27,8 @@ class HandoffStreamTextLiveTest < Test
       #{JSON.pretty_generate(records)}
     PROMPT
 
-    response = adapter.stream(prompt, reasoning: "high")
-    refute_equal "error", response.stop_reason, "#{provider}/#{model} failed: #{response.error_message}"
+    response = adapter.stream(prompt, reasoning: "high", **options)
+    refute_equal "error", response.stop_reason, "#{provider_name}/#{model} failed: #{response.error_message}"
 
     text = response.content.select { |block| block.type == "text" }.map(&:text).join(" ").downcase
     assert_includes text, records.length.to_s
@@ -36,16 +36,16 @@ class HandoffStreamTextLiveTest < Test
     assert_includes text, "3"
   end
 
-  def self.define_handoff_stream_test_for(provider:, model:)
-    test "handoff_stream_text__#{provider}_#{model}" do
-      with_vcr_adapter(provider:, model:) do |adapter|
-        run_handoff_stream_for(provider:, model:, adapter:)
+  def self.define_handoff_stream_test_for(provider_name:, provider:, model:, oauth:, options: {})
+    test "handoff_stream_text__#{provider_name}_#{model}" do
+      with_vcr_adapter(provider:, model:, oauth:) do |adapter|
+        run_handoff_stream_for(provider_name:, model:, adapter:, options:)
       end
     end
   end
 
   PAIRS.each do |pair|
-    define_handoff_stream_test_for(provider: pair[:provider], model: pair[:model])
+    define_handoff_stream_test_for(provider_name: pair[:name], provider: pair[:provider], model: pair[:model], oauth: pair[:oauth], options: pair.fetch(:options, {}))
   end
 
   private

--- a/test/integration/live/handoff_stream_tool_call_test.rb
+++ b/test/integration/live/handoff_stream_tool_call_test.rb
@@ -16,7 +16,7 @@ class HandoffStreamToolCallLiveTest < Test
     LlmGateway.reset_configuration!
   end
 
-  def run_handoff_stream_for(provider:, model:, adapter:)
+  def run_handoff_stream_for(provider_name:, model:, adapter:, options: {})
     records = load_recorded_outputs
 
     prompt = <<~PROMPT
@@ -27,24 +27,24 @@ class HandoffStreamToolCallLiveTest < Test
       #{JSON.pretty_generate(records)}
     PROMPT
 
-    response = adapter.stream(prompt, reasoning: "high")
-    refute_equal "error", response.stop_reason, "#{provider}/#{model} failed: #{response.error_message}"
+    response = adapter.stream(prompt, reasoning: "high", **options)
+    refute_equal "error", response.stop_reason, "#{provider_name}/#{model} failed: #{response.error_message}"
 
     text = response.content.select { |block| block.type == "text" }.map(&:text).join(" ").downcase
     assert_includes text, records.length.to_s
     assert_includes text, "42"
   end
 
-  def self.define_handoff_stream_test_for(provider:, model:)
-    test "handoff_stream_tool_call__#{provider}_#{model}" do
-      with_vcr_adapter(provider:, model:) do |adapter|
-        run_handoff_stream_for(provider:, model:, adapter:)
+  def self.define_handoff_stream_test_for(provider_name:, provider:, model:, oauth:, options: {})
+    test "handoff_stream_tool_call__#{provider_name}_#{model}" do
+      with_vcr_adapter(provider:, model:, oauth:) do |adapter|
+        run_handoff_stream_for(provider_name:, model:, adapter:, options:)
       end
     end
   end
 
   PAIRS.each do |pair|
-    define_handoff_stream_test_for(provider: pair[:provider], model: pair[:model])
+    define_handoff_stream_test_for(provider_name: pair[:name], provider: pair[:provider], model: pair[:model], oauth: pair[:oauth], options: pair.fetch(:options, {}))
   end
 
   private

--- a/test/integration/live/prompt_too_long_test.rb
+++ b/test/integration/live/prompt_too_long_test.rb
@@ -7,12 +7,12 @@ class PromptTooLongLiveTest < Test
   include LiveTestHelper
 
   PAIRS = [
-    { provider: "openai_apikey_completions", model: "gpt-5.1" },
-    { provider: "anthropic_apikey_messages", model: "claude-sonnet-4-20250514" },
-    { provider: "openai_apikey_responses", model: "gpt-5.4" },
-    { provider: "anthropic_oauth_messages", model: "claude-sonnet-4-20250514" },
-    { provider: "openai_oauth_codex", model: "gpt-5.4" },
-    { provider: "groq_completions", model: "openai/gpt-oss-120b" }
+    { name: "openai_apikey_completions", provider: "openai_completions", model: "gpt-5.1" },
+    { name: "anthropic_apikey_messages", provider: "anthropic_messages", model: "claude-sonnet-4-20250514" },
+    { name: "openai_apikey_responses", provider: "openai_responses", model: "gpt-5.4" },
+    { name: "anthropic_oauth_messages", provider: "anthropic_messages", model: "claude-sonnet-4-20250514", oauth: true },
+    { name: "openai_oauth_codex", provider: "openai_codex", model: "gpt-5.4" },
+    { name: "groq_completions", provider: "groq_completions", model: "openai/gpt-oss-120b" }
   ].freeze
 
   def teardown
@@ -32,15 +32,15 @@ class PromptTooLongLiveTest < Test
       "Expected prompt-length related error message for #{provider}, got: #{error.message}"
   end
 
-  def self.define_prompt_too_long_debug_test(provider:, model:, options: {})
-    test "live_prompt_too_long_#{provider}_#{model}" do
-      with_vcr_adapter(provider:, model:, redact_request_body: true) do |adapter|
-        assert_prompt_too_long(adapter, provider, options: options)
+  def self.define_prompt_too_long_debug_test(provider_name:, provider:, model:, oauth:, options: {})
+    test "live_prompt_too_long_#{provider_name}_#{model}" do
+      with_vcr_adapter(provider:, model:, redact_request_body: true, oauth:,) do |adapter|
+        assert_prompt_too_long(adapter, provider_name, options: options)
       end
     end
   end
 
   PAIRS.each do |pair|
-    define_prompt_too_long_debug_test(provider: pair[:provider], model: pair[:model], options: pair.fetch(:options, {}))
+    define_prompt_too_long_debug_test(provider_name: pair[:name], provider: pair[:provider], model: pair[:model], oauth: pair[:oauth], options: pair.fetch(:options, {}))
   end
 end

--- a/test/integration/live/stream_image_test.rb
+++ b/test/integration/live/stream_image_test.rb
@@ -9,12 +9,12 @@ class StreamImageTest < Test
   include LiveTestHelper
 
   PAIRS = [
-    { provider: "openai_apikey_completions", model: "gpt-5.1" },
-    { provider: "anthropic_apikey_messages", model: "claude-sonnet-4-20250514" },
-    { provider: "openai_apikey_responses", model: "gpt-5.4" },
-    { provider: "anthropic_oauth_messages", model: "claude-sonnet-4-20250514" },
-    { provider: "openai_oauth_codex", model: "gpt-5.4" },
-    { provider: "groq_completions", model: "meta-llama/llama-4-scout-17b-16e-instruct", options: { max_completion_tokens: 8192, reasoning: "none" } }
+    { name: "openai_apikey_completions", provider: "openai_completions", model: "gpt-5.1" },
+    { name: "anthropic_apikey_messages", provider: "anthropic_messages", model: "claude-sonnet-4-20250514" },
+    { name: "openai_apikey_responses", provider: "openai_responses", model: "gpt-5.4" },
+    { name: "anthropic_oauth_messages", provider: "anthropic_messages", model: "claude-sonnet-4-20250514", oauth: true },
+    { name: "openai_oauth_codex", provider: "openai_codex", model: "gpt-5.4" },
+    { name: "groq_completions", provider: "groq_completions", model: "meta-llama/llama-4-scout-17b-16e-instruct", options: { max_completion_tokens: 8192, reasoning: "none" } }
   ].freeze
 
   def teardown
@@ -59,16 +59,16 @@ class StreamImageTest < Test
     response
   end
 
-  def self.define_stream_image_tests_for(provider:, model:, options: {})
-    test "live_image_streaming_#{provider}_#{model}" do
-      with_vcr_adapter(provider:, model:) do |adapter|
+  def self.define_stream_image_tests_for(provider_name:, provider:, model:, oauth:, options: {})
+    test "live_image_streaming_#{provider_name}_#{model}" do
+      with_vcr_adapter(provider:, model:, oauth:,) do |adapter|
         response = basic_image_streaming_test(adapter, options: options)
-        record_live_handoff_result(test_file: __FILE__, provider:, model:, result: response)
+        record_live_handoff_result(test_file: __FILE__, provider: provider_name, model:, result: response)
       end
     end
   end
 
   PAIRS.each do |pair|
-    define_stream_image_tests_for(provider: pair[:provider], model: pair[:model], options: pair.fetch(:options, {}))
+    define_stream_image_tests_for(provider_name: pair[:name], provider: pair[:provider], model: pair[:model], oauth: pair[:oauth], options: pair.fetch(:options, {}))
   end
 end

--- a/test/integration/live/stream_reasoning_test.rb
+++ b/test/integration/live/stream_reasoning_test.rb
@@ -8,12 +8,12 @@ class StreamReasoningTest < Test
   include LiveTestHelper
 
   PAIRS = [
-    { provider: "openai_apikey_completions", model: "gpt-5.1" },
-    { provider: "anthropic_apikey_messages", model: "claude-sonnet-4-20250514" },
-    { provider: "openai_apikey_responses", model: "gpt-5.4" },
-    { provider: "anthropic_oauth_messages", model: "claude-sonnet-4-20250514" },
-    { provider: "openai_oauth_codex", model: "gpt-5.4" },
-    { provider: "groq_completions", model: "openai/gpt-oss-120b" }
+    { name: "openai_apikey_completions", provider: "openai_completions", model: "gpt-5.1" },
+    { name: "anthropic_apikey_messages", provider: "anthropic_messages", model: "claude-sonnet-4-20250514" },
+    { name: "openai_apikey_responses", provider: "openai_responses", model: "gpt-5.4" },
+    { name: "anthropic_oauth_messages", provider: "anthropic_messages", model: "claude-sonnet-4-20250514", oauth: true },
+    { name: "openai_oauth_codex", provider: "openai_codex", model: "gpt-5.4" },
+    { name: "groq_completions", provider: "groq_completions", model: "openai/gpt-oss-120b" }
   ].freeze
 
   def teardown
@@ -58,16 +58,16 @@ class StreamReasoningTest < Test
     response
   end
 
-  def self.define_stream_reasoning_tests_for(provider:, model:, options: {})
-    test "live_basic_thinking_#{provider}_#{model}" do
-      with_vcr_adapter(provider:, model:) do |adapter|
+  def self.define_stream_reasoning_tests_for(provider_name:, provider:, model:, oauth:, options: {})
+    test "live_basic_thinking_#{provider_name}_#{model}" do
+      with_vcr_adapter(provider:, model:, oauth:,) do |adapter|
         response = basic_thinking_test(adapter, reasoning: "high", options: options)
-        record_live_handoff_result(test_file: __FILE__, provider:, model:, result: response)
+        record_live_handoff_result(test_file: __FILE__, provider: provider_name, model:, result: response)
       end
     end
   end
 
   PAIRS.each do |pair|
-    define_stream_reasoning_tests_for(provider: pair[:provider], model: pair[:model], options: pair.fetch(:options, {}))
+    define_stream_reasoning_tests_for(provider_name: pair[:name], provider: pair[:provider], model: pair[:model], oauth: pair[:oauth], options: pair.fetch(:options, {}))
   end
 end

--- a/test/integration/live/stream_text_test.rb
+++ b/test/integration/live/stream_text_test.rb
@@ -8,12 +8,12 @@ class StreamTextTest < Test
   include LiveTestHelper
 
   PAIRS = [
-    { provider: "openai_apikey_completions", model: "gpt-5.1" },
-    { provider: "anthropic_apikey_messages", model: "claude-sonnet-4-20250514" },
-    { provider: "openai_apikey_responses", model: "gpt-5.4" },
-    { provider: "anthropic_oauth_messages", model: "claude-sonnet-4-20250514" },
-    { provider: "openai_oauth_codex", model: "gpt-5.4" },
-    { provider: "groq_completions", model: "openai/gpt-oss-120b" }
+    { name: "openai_apikey_completions", provider: "openai_completions", model: "gpt-5.1" },
+    { name: "anthropic_apikey_messages", provider: "anthropic_messages", model: "claude-sonnet-4-20250514" },
+    { name: "openai_apikey_responses", provider: "openai_responses", model: "gpt-5.4" },
+    { name: "anthropic_oauth_messages", provider: "anthropic_messages", model: "claude-sonnet-4-20250514", oauth: true },
+    { name: "openai_oauth_codex", provider: "openai_codex", model: "gpt-5.4" },
+    { name: "groq_completions", provider: "groq_completions", model: "openai/gpt-oss-120b" }
   ].freeze
 
   def teardown
@@ -46,16 +46,16 @@ class StreamTextTest < Test
     response
   end
 
-  def self.define_stream_tests_for(provider:, model:, options: {})
-    test "live_text_streaming_#{provider}_#{model}" do
-      with_vcr_adapter(provider:, model:) do |adapter|
+  def self.define_stream_tests_for(provider_name:, provider:, model:, oauth:, options: {})
+    test "live_text_streaming_#{provider_name}_#{model}" do
+      with_vcr_adapter(provider:, model:, oauth:,) do |adapter|
         response = basic_streaming_text_test(adapter, options: options)
-        record_live_handoff_result(test_file: __FILE__, provider:, model:, result: response)
+        record_live_handoff_result(test_file: __FILE__, provider: provider_name, model:, result: response)
       end
     end
   end
 
   PAIRS.each do |pair|
-    define_stream_tests_for(provider: pair[:provider], model: pair[:model], options: pair.fetch(:options, {}))
+    define_stream_tests_for(provider_name: pair[:name], provider: pair[:provider], model: pair[:model], oauth: pair[:oauth], options: pair.fetch(:options, {}))
   end
 end

--- a/test/integration/live/stream_tool_call_test.rb
+++ b/test/integration/live/stream_tool_call_test.rb
@@ -11,12 +11,12 @@ class StreamToolCallTest < Test
   include LiveTestHelper
 
   PAIRS = [
-    { provider: "openai_apikey_completions", model: "gpt-5.1" },
-    { provider: "anthropic_apikey_messages", model: "claude-sonnet-4-20250514" },
-    { provider: "openai_apikey_responses", model: "gpt-5.4" },
-    { provider: "anthropic_oauth_messages", model: "claude-sonnet-4-20250514" },
-    { provider: "openai_oauth_codex", model: "gpt-5.4" },
-    { provider: "groq_completions", model: "openai/gpt-oss-120b" }
+    { name: "openai_apikey_completions", provider: "openai_completions", model: "gpt-5.1" },
+    { name: "anthropic_apikey_messages", provider: "anthropic_messages", model: "claude-sonnet-4-20250514" },
+    { name: "openai_apikey_responses", provider: "openai_responses", model: "gpt-5.4" },
+    { name: "anthropic_oauth_messages", provider: "anthropic_messages", model: "claude-sonnet-4-20250514", oauth: true },
+    { name: "openai_oauth_codex", provider: "openai_codex", model: "gpt-5.4" },
+    { name: "groq_completions", provider: "groq_completions", model: "openai/gpt-oss-120b" }
   ].freeze
 
   def teardown
@@ -69,16 +69,16 @@ class StreamToolCallTest < Test
     response
   end
 
-  def self.define_stream_tests_for(provider:, model:, options: {})
-    test "live_basic_tool_call_#{provider}_#{model}" do
-      with_vcr_adapter(provider:, model:) do |adapter|
+  def self.define_stream_tests_for(provider_name:, provider:, model:, oauth:, options: {})
+    test "live_basic_tool_call_#{provider_name}_#{model}" do
+      with_vcr_adapter(provider:, model:, oauth:,) do |adapter|
         response = basic_tool_call(adapter, options: options)
-        record_live_handoff_result(test_file: __FILE__, provider:, model:, result: response)
+        record_live_handoff_result(test_file: __FILE__, provider: provider_name, model:, result: response)
       end
     end
   end
 
   PAIRS.each do |pair|
-    define_stream_tests_for(provider: pair[:provider], model: pair[:model], options: pair.fetch(:options, {}))
+    define_stream_tests_for(provider_name: pair[:name], provider: pair[:provider], model: pair[:model], oauth: pair[:oauth], options: pair.fetch(:options, {}))
   end
 end

--- a/test/utils/live_test_helper.rb
+++ b/test/utils/live_test_helper.rb
@@ -5,61 +5,35 @@ require "time"
 require "fileutils"
 
 module LiveTestHelper
-  def load_provider(provider:, model:, replaying_vcr: false)
+  def load_provider(provider:, model:, replaying_vcr: false, oauth:)
     config = {
       "provider" => provider,
       "model_key" => model
     }
-
-    case provider
-    when "openai_apikey_completions", "openai_apikey_responses"
-      api_key = ENV["OPENAI_API_KEY"].to_s
-      skip("Skipped: missing OPENAI_API_KEY") if api_key.empty?
-      config["api_key"] = api_key
-    when "anthropic_apikey_messages"
-      api_key = ENV["ANTHROPIC_API_KEY"].to_s
-      skip("Skipped: missing ANTHROPIC_API_KEY") if api_key.empty?
-      config["api_key"] = api_key
-    when "groq_completions"
-      config["api_key"] = "vcr-replay-token" if replaying_vcr
-      api_key = ENV["GROQ_API_KEY"].to_s
-      skip("Skipped: missing GROQ_API_KEY") if api_key.empty?
-      config["api_key"] = api_key
-    when "anthropic_oauth_messages"
-      config["provider"] = "anthropic_apikey_messages"
-      config["api_key"] = replaying_vcr ? "sk-ant-oat-vcr-replay-token" : oauth_access_token_for("anthropic")
-    when "openai_oauth_codex"
-      if replaying_vcr
-        config["api_key"] = "vcr-replay-token"
-        config["account_id"] = "vcr-replay-account"
-      else
-        creds = load_auth_credentials("openai")
-        config["api_key"] = oauth_access_token_for("openai")
-        config["account_id"] = creds["account_id"] if creds["account_id"]
+    if provider == "openai_codex"
+      config["api_key"] = replaying_vcr ? "vcr-replay-token" : oauth_access_token_for("openai")
+      config["account_id"] = replaying_vcr ? "vcr-replay-account" : load_auth_credentials("openai")["account_id"]
+    elsif oauth == true
+      if provider == "anthropic_messages"
+        config["api_key"] = replaying_vcr ? "sk-ant-oat-vcr-replay-token" : oauth_access_token_for("anthropic")
       end
+    elsif replaying_vcr
+      config["api_key"] = "vcr-replay-token"
     end
 
     LlmGateway.build_provider(config)
   end
 
-  def skip_on_authentication_error
-    yield
-  rescue LlmGateway::Errors::AuthenticationError => e
-    skip("Skipped due to authentication error: #{e.message}")
-  end
-
-  def with_vcr_adapter(provider:, model:, redact_request_body: false)
+  def with_vcr_adapter(provider:, model:, redact_request_body: false, oauth: false)
     cassette_name = vcr_cassette_name
     match_requests_on = redact_request_body ? %i[method uri] : %i[method uri json_body]
-    replaying_vcr = oauth_provider?(provider) && File.exist?(vcr_cassette_path(cassette_name))
+    replaying_vcr = File.exist?(vcr_cassette_path(cassette_name))
 
     cassette_options = { match_requests_on: match_requests_on }
     cassette_options[:tag] = :redact_large_request_body if redact_request_body
 
     VCR.use_cassette(cassette_name, cassette_options) do
-      skip_on_authentication_error do
-        yield load_provider(provider: provider, model: model, replaying_vcr: replaying_vcr)
-      end
+      yield load_provider(provider: provider, model: model, replaying_vcr: replaying_vcr, oauth:,)
     end
   end
 
@@ -86,10 +60,6 @@ module LiveTestHelper
     end
   end
 
-  def oauth_provider?(provider)
-    %w[anthropic_oauth_messages openai_oauth_codex].include?(provider)
-  end
-
   def vcr_cassette_path(cassette_name)
     direct_path = File.join(VCR.configuration.cassette_library_dir, "#{cassette_name}.yml")
     return direct_path if File.exist?(direct_path)
@@ -104,13 +74,8 @@ module LiveTestHelper
 
   def load_auth_credentials(provider)
     path = auth_file_path
-    skip("Skipped: missing auth file at #{path}") unless File.exist?(path)
-
     auth = JSON.parse(File.read(path))
-    creds = auth[provider]
-    skip("Skipped: missing #{provider} credentials in #{path}") unless creds
-
-    creds
+    auth[provider]
   end
 
   def persist_auth_credentials(provider, attributes)


### PR DESCRIPTION
# Goal
Remove support for legacy provider keys and standardize docs/tests on the current provider names.

# Changes made to achieve the goal
Updated examples, configuration tests, client builder tests, and live test helpers to use the current provider identifiers. Removed deprecated provider aliases and simplified live test credential handling around
current API-key and OAuth providers.

> read the commit messages for more details