### PR TITLE
Decouple model selection from provider auth configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ gem "llm_gateway"
 | OpenAI Codex | `openai_codex`            | OAuth   | Responses            |
 | Groq      | `groq_completions`           | API key | Chat Completions     |
 
-Legacy keys (`*_apikey_*`, `*_oauth_*`) are still supported for backward compatibility.
+Provider configuration only contains auth/client settings (for example `api_key` or `access_token`). Pass the model per request with `model:` when calling `chat` or `stream`.
 
 ## Stream Options
 
@@ -116,10 +116,8 @@ require "json"
 # Build a provider adapter directly (not via prebuilt config)
 adapter = LlmGateway.build_provider(
   provider: "openai_responses", # or anthropic_messages, groq_completions, ...
-  api_key: ENV.fetch("OPENAI_API_KEY"),
-  model_key: "gpt-5.4"
+  api_key: ENV.fetch("OPENAI_API_KEY")
 )
-
 tools = [
   {
     name: "get_time",
@@ -139,7 +137,7 @@ transcript = [
 
 streamed_tool_args = Hash.new { |h, k| h[k] = +"" }
 
-response = adapter.stream(transcript, tools: tools, reasoning: "high") do |event|
+response = adapter.stream(transcript, tools: tools, model: "gpt-5.4", reasoning: "high") do |event|
   case event.type
   # AssistantStreamMessageEvent
   when :message_start
@@ -223,11 +221,10 @@ require "llm_gateway"
 
 adapter = LlmGateway.build_provider(
   provider: "openai_responses",
-  api_key: ENV.fetch("OPENAI_API_KEY"),
-  model_key: "gpt-5.4"
+  api_key: ENV.fetch("OPENAI_API_KEY")
 )
 
-result = adapter.stream("Write one short sentence about Ruby.")
+result = adapter.stream("Write one short sentence about Ruby.", model: "gpt-5.4")
 
 puts result.role         # "assistant"
 puts result.stop_reason  # "stop" (usually)
@@ -278,10 +275,8 @@ require "json"
 
 adapter = LlmGateway.build_provider(
   provider: "openai_responses",
-  api_key: ENV.fetch("OPENAI_API_KEY"),
-  model_key: "gpt-5.4"
+  api_key: ENV.fetch("OPENAI_API_KEY")
 )
-
 weather_tool = {
   name: "get_weather",
   description: "Get current weather for a location",
@@ -310,7 +305,7 @@ transcript = [
 ]
 
 # 1) First model pass (stream API, no event block)
-response = adapter.stream(transcript, tools: [weather_tool])
+response = adapter.stream(transcript, tools: [weather_tool], model: "gpt-5.4")
 transcript << response.to_h
 
 # 2) Execute tool calls returned by the model
@@ -333,7 +328,7 @@ end
 
 # 3) Continue the conversation after tool execution
 if response.content.any? { |b| b.type == "tool_use" }
-  final_response = adapter.stream(transcript, tools: [weather_tool])
+  final_response = adapter.stream(transcript, tools: [weather_tool], model: "gpt-5.4")
 
   final_text = final_response.content
     .select { |b| b.type == "text" }
@@ -359,10 +354,8 @@ require "base64"
 
 adapter = LlmGateway.build_provider(
   provider: "openai_responses",
-  api_key: ENV.fetch("OPENAI_API_KEY"),
-  model_key: "gpt-5.4"
+  api_key: ENV.fetch("OPENAI_API_KEY")
 )
-
 image_b64 = Base64.strict_encode64(File.binread("./chart.png"))
 
 message = [
@@ -375,7 +368,7 @@ message = [
   }
 ]
 
-result = adapter.stream(message) # stream API, no event block
+result = adapter.stream(message, model: "gpt-5.4") # stream API, no event block
 
 text = result.content
   .select { |b| b.type == "text" }
@@ -396,12 +389,12 @@ require "llm_gateway"
 
 adapter = LlmGateway.build_provider(
   provider: "openai_responses",
-  api_key: ENV.fetch("OPENAI_API_KEY"),
-  model_key: "gpt-5.4"
+  api_key: ENV.fetch("OPENAI_API_KEY")
 )
 
 result = adapter.stream(
   "Think step by step and then compute 482 * 17.",
+  model: "gpt-5.4",
   reasoning: "high"
 )
 
@@ -426,7 +419,7 @@ If you want incremental thinking/reasoning tokens as they arrive, pass a block t
 ```ruby
 reasoning_text = +""
 
-result = adapter.stream("Solve 99 * 99 with brief reasoning.", reasoning: "high") do |event|
+result = adapter.stream("Solve 99 * 99 with brief reasoning.", model: "gpt-5.4", reasoning: "high") do |event|
   case event.type
   when :reasoning_start
     print "\n[thinking start]\n"
@@ -505,17 +498,15 @@ require "json"
 
 adapter = LlmGateway.build_provider(
   provider: "openai_responses",
-  api_key: ENV.fetch("OPENAI_API_KEY"),
-  model_key: "gpt-5.4"
+  api_key: ENV.fetch("OPENAI_API_KEY")
 )
-
 # Build context (transcript)
 transcript = [
   { role: "user", content: "Plan a 3-day trip to Tokyo." }
 ]
 
 # Run one turn and persist assistant output
-first = adapter.stream(transcript)
+first = adapter.stream(transcript, model: "gpt-5.4")
 transcript << first.to_h
 
 # Serialize (store in DB/file/cache)
@@ -526,7 +517,7 @@ restored_transcript = JSON.parse(json_context)
 
 # Continue conversation from restored context
 restored_transcript << { role: "user", content: "Now make it budget-friendly." }
-second = adapter.stream(restored_transcript)
+second = adapter.stream(restored_transcript, model: "gpt-5.4")
 
 puts second.content.select { |b| b.type == "text" }.map(&:text).join
 ```
@@ -648,11 +639,10 @@ Build the provider with the current access token:
 ```ruby
 adapter = LlmGateway.build_provider(
   provider: "openai_codex",
-  access_token: current_access_token,
-  model_key: "gpt-5.4"
+  access_token: current_access_token
 )
 
-result = adapter.stream("Hello from OAuth auth")
+result = adapter.stream("Hello from OAuth auth", model: "gpt-5.4")
 puts result.content.select { |b| b.type == "text" }.map(&:text).join
 ```
 

--- a/lib/llm_gateway.rb
+++ b/lib/llm_gateway.rb
@@ -100,6 +100,9 @@ module LlmGateway
   def self.build_provider(config)
     config = config.transform_keys(&:to_sym)
     provider_name = config.delete(:provider)
+    if config.key?(:model_key)
+      raise ArgumentError, "model_key is no longer a provider option; pass model: to chat/stream instead"
+    end
     entry = ProviderRegistry.resolve(provider_name)
 
     client = entry[:client].new(**config)

--- a/lib/llm_gateway/adapters/adapter.rb
+++ b/lib/llm_gateway/adapters/adapter.rb
@@ -15,7 +15,7 @@ module LlmGateway
         raise LlmGateway::Errors::MissingMapperForProvider, "No stream_mapper configured" unless stream_mapper
 
         normalized_input = map_input({
-          messages: sanitize_messages(normalize_messages(message)),
+          messages: sanitize_messages(normalize_messages(message), target_model: options[:model]),
           tools: tools,
           system: normalize_system(system)
         })
@@ -99,12 +99,11 @@ module LlmGateway
         nil
       end
 
-      def sanitize_messages(messages)
+      def sanitize_messages(messages, target_model: nil)
         return messages unless input_sanitizer
 
         target_provider = LlmGateway::Client.provider_id_from_client(client)
         target_api = api_name
-        target_model = client.model_key
 
         return messages if target_provider.nil? || target_api.nil? || target_model.nil?
 

--- a/lib/llm_gateway/base_client.rb
+++ b/lib/llm_gateway/base_client.rb
@@ -6,11 +6,9 @@ require "json"
 
 module LlmGateway
   class BaseClient
-    attr_accessor
-    attr_reader :api_key, :model_key, :base_endpoint
+    attr_reader :api_key, :base_endpoint
 
-    def initialize(model_key:, api_key:)
-      @model_key = model_key
+    def initialize(api_key:)
       @api_key = api_key
     end
 

--- a/lib/llm_gateway/clients/anthropic.rb
+++ b/lib/llm_gateway/clients/anthropic.rb
@@ -9,10 +9,11 @@ module LlmGateway
   module Clients
     class Anthropic < BaseClient
       CLAUDE_CODE_VERSION = "2.1.2"
+      DEFAULT_MODEL = "claude-3-7-sonnet-20250219"
 
-      def initialize(model_key: "claude-3-7-sonnet-20250219", api_key: ENV["ANTHROPIC_API_KEY"])
+      def initialize(api_key: ENV["ANTHROPIC_API_KEY"])
         @base_endpoint = "https://api.anthropic.com/v1"
-        super(model_key: model_key, api_key: api_key)
+        super(api_key: api_key)
       end
 
       def chat(messages, **kwargs)
@@ -44,11 +45,11 @@ module LlmGateway
 
       private
 
-      def build_body(messages, tools: nil, system: [], cache_retention: nil, **options)
+      def build_body(messages, tools: nil, system: [], cache_retention: nil, model: DEFAULT_MODEL, **options)
         cache_control = anthropic_cache_control_for(cache_retention)
 
         body = {
-          model: model_key,
+          model: model,
           messages: messages
         }
 

--- a/lib/llm_gateway/clients/groq.rb
+++ b/lib/llm_gateway/clients/groq.rb
@@ -5,14 +5,16 @@ require_relative "../base_client"
 module LlmGateway
   module Clients
     class Groq < BaseClient
-      def initialize(model_key: "openai/gpt-oss-120b", api_key: ENV["GROQ_API_KEY"])
+      DEFAULT_MODEL = "openai/gpt-oss-120b"
+
+      def initialize(api_key: ENV["GROQ_API_KEY"])
         @base_endpoint = "https://api.groq.com/openai/v1"
-        super(model_key: model_key, api_key: api_key)
+        super(api_key: api_key)
       end
 
-      def chat(messages, tools: nil, system: [], **options)
+      def chat(messages, tools: nil, system: [], model: DEFAULT_MODEL, **options)
         body = {
-          model: model_key,
+          model: model,
           messages: system + messages,
           tools: tools
         }
@@ -21,9 +23,9 @@ module LlmGateway
         post("chat/completions", body)
       end
 
-      def stream(messages, tools: nil, system: [], **options, &block)
+      def stream(messages, tools: nil, system: [], model: DEFAULT_MODEL, **options, &block)
         body = {
-          model: model_key,
+          model: model,
           messages: system + messages,
           tools: tools,
           stream_options: { include_usage: true }

--- a/lib/llm_gateway/clients/openai.rb
+++ b/lib/llm_gateway/clients/openai.rb
@@ -6,18 +6,20 @@ module LlmGateway
   module Clients
     class OpenAI < BaseClient
       CODEX_BASE_ENDPOINT = "https://chatgpt.com/backend-api/codex"
+      DEFAULT_MODEL = "gpt-4o"
+      DEFAULT_EMBEDDINGS_MODEL = "text-embedding-3-small"
 
       attr_reader :account_id
 
-      def initialize(model_key: "gpt-4o", api_key: ENV["OPENAI_API_KEY"], account_id: nil)
+      def initialize(api_key: ENV["OPENAI_API_KEY"], account_id: nil)
         @base_endpoint = "https://api.openai.com/v1"
         @account_id = account_id
-        super(model_key: model_key, api_key: api_key)
+        super(api_key: api_key)
       end
 
-      def chat(messages, tools: nil, system: [], **options)
+      def chat(messages, tools: nil, system: [], model: DEFAULT_MODEL, **options)
         body = {
-          model: model_key,
+          model: model,
           messages: system + messages
         }
         body[:tools] = tools if tools
@@ -26,9 +28,9 @@ module LlmGateway
         post("chat/completions", body)
       end
 
-      def stream(messages, tools: nil, system: [], **options, &block)
+      def stream(messages, tools: nil, system: [], model: DEFAULT_MODEL, **options, &block)
         body = {
-          model: model_key,
+          model: model,
           messages: system + messages
         }
         body[:tools] = tools if tools
@@ -38,9 +40,9 @@ module LlmGateway
         post_stream("chat/completions", body, &block)
       end
 
-      def responses(messages, tools: nil, system: [], **options)
+      def responses(messages, tools: nil, system: [], model: DEFAULT_MODEL, **options)
         body = {
-          model: model_key,
+          model: model,
           input: messages.flatten
         }
         body[:instructions] = system[0][:content] if system.any?
@@ -50,9 +52,9 @@ module LlmGateway
         post("responses", body)
       end
 
-      def stream_responses(messages, tools: nil, system: [], **options, &block)
+      def stream_responses(messages, tools: nil, system: [], model: DEFAULT_MODEL, **options, &block)
         body = {
-          model: model_key,
+          model: model,
           input: messages.flatten
         }
         body[:instructions] = system[0][:content] if system.any?
@@ -74,8 +76,8 @@ module LlmGateway
         token_manager.access_token
       end
 
-      def chat_codex(messages, tools: nil, system: [], account_id: nil, **options)
-        body = build_codex_body(messages, system, tools, **options)
+      def chat_codex(messages, tools: nil, system: [], account_id: nil, model: DEFAULT_MODEL, **options)
+        body = build_codex_body(messages, system, tools, model: model, **options)
 
         completed_response = nil
         post_codex_stream("responses", body, account_id: account_id) do |raw_sse|
@@ -87,8 +89,8 @@ module LlmGateway
         completed_response
       end
 
-      def stream_codex(messages, tools: nil, system: [], account_id: nil, **options, &block)
-        body = build_codex_body(messages, system, tools, **options)
+      def stream_codex(messages, tools: nil, system: [], account_id: nil, model: DEFAULT_MODEL, **options, &block)
+        body = build_codex_body(messages, system, tools, model: model, **options)
         post_codex_stream("responses", body, account_id: account_id, &block)
       end
 
@@ -96,10 +98,10 @@ module LlmGateway
         get("files/#{file_id}/content")
       end
 
-      def generate_embeddings(input)
+      def generate_embeddings(input, model: DEFAULT_EMBEDDINGS_MODEL)
         body = {
           input:,
-          model: model_key
+          model: model
         }
         post("embeddings", body)
       end
@@ -110,12 +112,12 @@ module LlmGateway
 
       private
 
-      def build_codex_body(messages, system, tools, **options)
+      def build_codex_body(messages, system, tools, model:, **options)
         instructions = Array(system).filter_map { |s| s.is_a?(Hash) ? s[:content] : s }.join("\n")
         instructions = "You are a helpful assistant." if instructions.empty?
 
         body = {
-          model: model_key,
+          model: model,
           instructions: instructions,
           input: messages,
           store: false,

--- a/lib/llm_gateway/prompt.rb
+++ b/lib/llm_gateway/prompt.rb
@@ -2,7 +2,29 @@
 
 module LlmGateway
   class Prompt
-    attr_reader :model
+    UNSET = Object.new.freeze
+
+    attr_reader :provider, :model
+
+    class << self
+      def provider(value = UNSET)
+        @provider = value unless value.equal?(UNSET)
+        @provider
+      end
+
+      def provider=(value)
+        @provider = value
+      end
+
+      def model(value = UNSET)
+        @model = value unless value.equal?(UNSET)
+        @model
+      end
+
+      def model=(value)
+        @model = value
+      end
+    end
 
     def self.before_execute(*methods, &block)
       before_execute_callbacks.concat(methods)
@@ -26,23 +48,19 @@ module LlmGateway
       super
       subclass.instance_variable_set(:@before_execute_callbacks, before_execute_callbacks.dup)
       subclass.instance_variable_set(:@after_execute_callbacks, after_execute_callbacks.dup)
+      subclass.provider = provider
+      subclass.model = model
     end
 
-    def initialize(model)
-      @model = model
-      @connection = if model.is_a?(String)
-        LlmGateway.configured_clients.values.find do |client|
-          client.client.model_key == model
-        end
-      else
-        model
-      end
+    def initialize(provider = nil, model = nil)
+      @provider = provider || self.class.provider
+      @model = model || self.class.model
     end
 
     def run
       run_callbacks(:before_execute, prompt)
 
-      response = post
+      response = stream
 
       response_content = if respond_to?(:extract_response)
         extract_response(response)
@@ -61,12 +79,12 @@ module LlmGateway
       result
     end
 
-    def post
-      if @connection
-        @connection.chat(prompt, tools: tools, system: system_prompt)
-      else
-        LlmGateway::Client.chat(model, prompt, tools: tools, system: system_prompt)
-      end
+    def stream(provider: nil, model: nil, **options)
+      stream_provider = provider || self.provider
+      stream_model = model || self.model
+      options[:model] = stream_model if stream_model
+
+      stream_provider.stream(prompt, tools: tools, system: system_prompt, **options)
     end
 
     def tools

--- a/test/integration/clients/claude_test.rb
+++ b/test/integration/clients/claude_test.rb
@@ -44,7 +44,7 @@ class ClaudeClientTest < Test
   test "throws not found error" do
     error = assert_raises(LlmGateway::Errors::NotFoundError) do
       VCR.use_cassette(vcr_cassette_name) do
-        LlmGateway::Clients::Anthropic.new(model_key: "randomodel").chat([ { 'role': "user", 'content': "hello" } ], max_tokens: 4096)
+        LlmGateway::Clients::Anthropic.new.chat([ { 'role': "user", 'content': "hello" } ], model: "randomodel", max_tokens: 4096)
       end
     end
     assert_equal "model: randomodel", error.message

--- a/test/integration/clients/groq_test.rb
+++ b/test/integration/clients/groq_test.rb
@@ -45,7 +45,7 @@ class GroqClientTest < Test
   test "throws not found error" do
     error = assert_raises(LlmGateway::Errors::NotFoundError) do
       VCR.use_cassette(vcr_cassette_name) do
-        LlmGateway::Clients::Groq.new(model_key: "randomodel").chat([ { 'role': "user", 'content': "hello" } ], **mapped_options(max_completion_tokens: 4096))
+        LlmGateway::Clients::Groq.new.chat([ { 'role': "user", 'content': "hello" } ], model: "randomodel", **mapped_options(max_completion_tokens: 4096))
       end
     end
     assert_equal "The model `randomodel` does not exist or you do not have access to it.", error.message

--- a/test/integration/clients/openai_test.rb
+++ b/test/integration/clients/openai_test.rb
@@ -46,7 +46,7 @@ class OpenaiClientTest < Test
   test "throws not found error" do
     error = assert_raises(LlmGateway::Errors::NotFoundError) do
       VCR.use_cassette(vcr_cassette_name) do
-        LlmGateway::Clients::OpenAI.new(model_key: "randomodel").chat([ { 'role': "user", 'content': "hello" } ], **mapped_chat_options(max_completion_tokens: 4096))
+        LlmGateway::Clients::OpenAI.new.chat([ { 'role': "user", 'content': "hello" } ], model: "randomodel", **mapped_chat_options(max_completion_tokens: 4096))
       end
     end
     assert_equal "The model `randomodel` does not exist or you do not have access to it.", error.message
@@ -54,7 +54,7 @@ class OpenaiClientTest < Test
 
   test "embeddings api" do
     VCR.use_cassette(vcr_cassette_name) do
-      response = LlmGateway::Clients::OpenAI.new(model_key: "text-embedding-3-small").generate_embeddings("hello world")
+      response = LlmGateway::Clients::OpenAI.new.generate_embeddings("hello world", model: "text-embedding-3-small")
       assert(response[:usage], prompt_tokens: 2, total_tokens: 2)
       assert(response[:object], "list")
       assert(response[:model], "text-embedding-3-small")

--- a/test/unit/options/anthropic_option_mapper_test.rb
+++ b/test/unit/options/anthropic_option_mapper_test.rb
@@ -76,12 +76,12 @@ class AnthropicOptionMapperTest < Test
     attr_reader :options
 
     def initialize
-      super(model_key: "claude-sonnet-4-20250514", api_key: "test-key")
+      super(api_key: "test-key")
     end
 
-    def stream(_messages, tools:, system:, **options)
+    def stream(_messages, tools:, system:, model: DEFAULT_MODEL, **options)
       @options = options
-      yield({ event: "message_start", data: { message: { id: "msg_123", model: model_key, role: "assistant" } } })
+      yield({ event: "message_start", data: { message: { id: "msg_123", model: model, role: "assistant" } } })
       yield({ event: "message_delta", data: { delta: { stop_reason: "end_turn" } } })
       yield({ event: "message_stop", data: {} })
     end

--- a/test/unit/options/claude_cache_control_test.rb
+++ b/test/unit/options/claude_cache_control_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class ClaudeCacheControlTest < Test
   test "when cache retention is passed it adds cache_control to last system and tool blocks and sets top-level cache_control" do
-    client = LlmGateway::Clients::Anthropic.new(model_key: "claude-3", api_key: "test")
+    client = LlmGateway::Clients::Anthropic.new(api_key: "test")
 
     body = client.send(
       :build_body,
@@ -21,7 +21,8 @@ class ClaudeCacheControlTest < Test
         { name: "tool_1", description: "Tool 1", input_schema: { type: "object", properties: {} } },
         { name: "tool_2", description: "Tool 2", input_schema: { type: "object", properties: {} } }
       ],
-      cache_retention: "short"
+      cache_retention: "short",
+      model: "claude-3"
     )
 
     expected_cache_control = { type: "ephemeral" }
@@ -43,14 +44,15 @@ class ClaudeCacheControlTest < Test
   end
 
   test "uses ttl for long retention on official anthropic base url" do
-    client = LlmGateway::Clients::Anthropic.new(model_key: "claude-3", api_key: "test")
+    client = LlmGateway::Clients::Anthropic.new(api_key: "test")
 
     body = client.send(
       :build_body,
       [ { role: "user", content: [ { type: "text", text: "hello" } ] } ],
       system: [ { type: "text", text: "system" } ],
       tools: [ { name: "tool_1", description: "Tool 1", input_schema: { type: "object", properties: {} } } ],
-      cache_retention: "long"
+      cache_retention: "long",
+      model: "claude-3"
     )
 
     assert_equal({ type: "ephemeral", ttl: "1h" }, body[:cache_control])
@@ -60,14 +62,15 @@ class ClaudeCacheControlTest < Test
   end
 
   test "does not mutate existing cache control when retention is none" do
-    client = LlmGateway::Clients::Anthropic.new(model_key: "claude-3", api_key: "test")
+    client = LlmGateway::Clients::Anthropic.new(api_key: "test")
 
     body = client.send(
       :build_body,
       [ { role: "user", content: [ { type: "text", text: "hello", cache_control: { type: "ephemeral" } } ] } ],
       system: [ { type: "text", text: "system", cache_control: { type: "ephemeral" } } ],
       tools: [ { name: "tool_1", description: "Tool 1", cache_control: { type: "ephemeral" }, input_schema: { type: "object", properties: {} } } ],
-      cache_retention: "none"
+      cache_retention: "none",
+      model: "claude-3"
     )
 
     assert_nil body[:cache_control]

--- a/test/unit/options/groq_option_mapper_test.rb
+++ b/test/unit/options/groq_option_mapper_test.rb
@@ -84,12 +84,12 @@ class GroqOptionMapperTest < Test
     attr_reader :options
 
     def initialize
-      super(model_key: "openai/gpt-oss-120b", api_key: "test-key")
+      super(api_key: "test-key")
     end
 
-    def stream(_messages, tools:, system:, **options)
+    def stream(_messages, tools:, system:, model: DEFAULT_MODEL, **options)
       @options = options
-      yield({ data: { id: "chatcmpl_123", model: model_key, choices: [ { delta: { role: "assistant" } } ] } })
+      yield({ data: { id: "chatcmpl_123", model: model, choices: [ { delta: { role: "assistant" } } ] } })
       yield({ data: { choices: [ { delta: { content: "hi" } } ] } })
       yield({ data: { choices: [ { finish_reason: "stop" } ] } })
       yield({ data: { choices: [], usage: {} } })

--- a/test/unit/options/openai_chat_completions_option_mapper_test.rb
+++ b/test/unit/options/openai_chat_completions_option_mapper_test.rb
@@ -77,12 +77,12 @@ class OpenAIChatCompletionsOptionMapperTest < Test
     attr_reader :options
 
     def initialize
-      super(model_key: "gpt-4o", api_key: "test-key")
+      super(api_key: "test-key")
     end
 
-    def stream(_messages, tools:, system:, **options)
+    def stream(_messages, tools:, system:, model: DEFAULT_MODEL, **options)
       @options = options
-      yield({ data: { id: "chatcmpl_123", model: model_key, choices: [ { delta: { role: "assistant" } } ] } })
+      yield({ data: { id: "chatcmpl_123", model: model, choices: [ { delta: { role: "assistant" } } ] } })
       yield({ data: { choices: [ { delta: { content: "hi" } } ] } })
       yield({ data: { choices: [ { finish_reason: "stop" } ] } })
       yield({ data: { choices: [], usage: {} } })

--- a/test/unit/options/openai_responses_option_mapper_test.rb
+++ b/test/unit/options/openai_responses_option_mapper_test.rb
@@ -111,16 +111,16 @@ class OpenAIResponsesOptionMapperTest < Test
     attr_reader :options
 
     def initialize
-      super(model_key: "gpt-4o", api_key: "test-key")
+      super(api_key: "test-key")
     end
 
-    def stream_responses(_messages, tools:, system:, **options)
+    def stream_responses(_messages, tools:, system:, model: DEFAULT_MODEL, **options)
       @options = options
       yield({ event: "response.output_item.added", data: { output_index: 0, item: { type: "message", role: "assistant" } } })
       yield({ event: "response.content_part.added", data: { output_index: 0, part: { type: "output_text", text: "" } } })
       yield({ event: "response.output_text.delta", data: { output_index: 0, delta: "hi" } })
       yield({ event: "response.output_text.done", data: { output_index: 0, text: "hi" } })
-      yield({ event: "response.completed", data: { response: { id: "resp_123", model: model_key, status: "completed", usage: {} } } })
+      yield({ event: "response.completed", data: { response: { id: "resp_123", model: model, status: "completed", usage: {} } } })
     end
   end
 end

--- a/test/unit/prompt_test.rb
+++ b/test/unit/prompt_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class PromptTest < Test
+  class RecordingProvider
+    attr_reader :calls
+
+    def initialize
+      @calls = []
+    end
+
+    def stream(message, **options)
+      @calls << { message: message, options: options }
+      { choices: [ { content: "ok" } ] }
+    end
+  end
+
+  class ConfigurablePrompt < LlmGateway::Prompt
+    def prompt
+      "hello"
+    end
+  end
+
+  def setup
+    ConfigurablePrompt.provider = nil
+    ConfigurablePrompt.model = nil
+  end
+
+  test "uses provider and model configured on the class" do
+    provider = RecordingProvider.new
+    ConfigurablePrompt.provider = provider
+    ConfigurablePrompt.model = "class-model"
+
+    ConfigurablePrompt.new.stream
+
+    assert_equal "hello", provider.calls.last[:message]
+    assert_equal "class-model", provider.calls.last[:options][:model]
+  end
+
+  test "initializer provider and model override class configuration" do
+    class_provider = RecordingProvider.new
+    instance_provider = RecordingProvider.new
+    ConfigurablePrompt.provider = class_provider
+    ConfigurablePrompt.model = "class-model"
+
+    ConfigurablePrompt.new(instance_provider, "instance-model").stream
+
+    assert_empty class_provider.calls
+    assert_equal "instance-model", instance_provider.calls.last[:options][:model]
+  end
+
+  test "stream provider and model override instance configuration" do
+    instance_provider = RecordingProvider.new
+    stream_provider = RecordingProvider.new
+
+    ConfigurablePrompt.new(instance_provider, "instance-model").stream(
+      provider: stream_provider,
+      model: "stream-model"
+    )
+
+    assert_empty instance_provider.calls
+    assert_equal "stream-model", stream_provider.calls.last[:options][:model]
+  end
+end

--- a/test/utils/live_test_helper.rb
+++ b/test/utils/live_test_helper.rb
@@ -5,10 +5,31 @@ require "time"
 require "fileutils"
 
 module LiveTestHelper
+  ModelBoundAdapter = Struct.new(:adapter, :model) do
+    def chat(message, tools: nil, system: nil, **options)
+      adapter.chat(message, tools: tools, system: system, model: model, **options)
+    end
+
+    def stream(message, tools: nil, system: nil, **options, &block)
+      adapter.stream(message, tools: tools, system: system, model: model, **options, &block)
+    end
+
+    def method_missing(name, *args, **kwargs, &block)
+      if adapter.respond_to?(name)
+        adapter.public_send(name, *args, **kwargs, &block)
+      else
+        super
+      end
+    end
+
+    def respond_to_missing?(name, include_private = false)
+      adapter.respond_to?(name, include_private) || super
+    end
+  end
+
   def load_provider(provider:, model:, replaying_vcr: false, oauth:)
     config = {
-      "provider" => provider,
-      "model_key" => model
+      "provider" => provider
     }
     if provider == "openai_codex"
       config["api_key"] = replaying_vcr ? "vcr-replay-token" : oauth_access_token_for("openai")
@@ -21,7 +42,7 @@ module LiveTestHelper
       config["api_key"] = "vcr-replay-token"
     end
 
-    LlmGateway.build_provider(config)
+    ModelBoundAdapter.new(LlmGateway.build_provider(config), model)
   end
 
   def with_vcr_adapter(provider:, model:, redact_request_body: false, oauth: false)
@@ -91,6 +112,7 @@ module LiveTestHelper
 
   def oauth_access_token_for(provider)
     creds = load_auth_credentials(provider)
+    return creds["access_token"] if defined?(VCR) && VCR.current_cassette && !creds["access_token"].to_s.empty?
 
     case provider
     when "anthropic"


### PR DESCRIPTION
# Goal
Decouple model selection from provider authentication/configuration so auth can be defined independently and reused across model calls.

# Changes made to achieve the goal
Refactor clients and provider prompts so model selection is passed at call time rather than being tightly bound to client construction or auth setup. Clean up deprecated paths and align naming with the streaming adapter API.

> read the commit messages for more details