### PR TITLE
feat: add partial message as part of streaming events

### DIFF
--- a/lib/llm_gateway/adapters/normalized_stream_accumulator.rb
+++ b/lib/llm_gateway/adapters/normalized_stream_accumulator.rb
@@ -97,10 +97,11 @@ module LlmGateway
         type = event_patch.fetch(:type).to_sym
         event_patch = prepare_event_patch(event_patch.merge(type:), type)
 
-        event = build_event(event_patch)
+        event = build_event(event_patch, partial: empty_partial)
         accumulate(event)
         content_index = event.content_index if event.respond_to?(:content_index)
         commit_block_transition(type, content_index)
+        event = build_event(event_patch, partial: partial_message)
         block.call(event) if block
 
         nil
@@ -166,7 +167,7 @@ module LlmGateway
         end
       end
 
-      def build_event(event_patch)
+      def build_event(event_patch, partial:)
         event_patch = symbolize_keys(event_patch)
         type = event_patch.fetch(:type).to_sym
 
@@ -175,7 +176,8 @@ module LlmGateway
           AssistantStreamMessageEvent.new(
             type:,
             delta: symbolize_keys(event_patch[:delta] || {}),
-            usage_increment: symbolize_keys(event_patch[:usage_increment] || {})
+            usage_increment: symbolize_keys(event_patch[:usage_increment] || {}),
+            partial:
           )
         when :tool_start
           AssistantToolStartEvent.new(
@@ -183,20 +185,23 @@ module LlmGateway
             content_index: event_patch.fetch(:content_index),
             delta: string_value(event_patch[:delta]),
             id: event_patch[:id],
-            name: event_patch[:name]
+            name: event_patch[:name],
+            partial:
           )
         when :reasoning_start, :reasoning_delta, :reasoning_end
           AssistantStreamReasoningEvent.new(
             type:,
             content_index: event_patch.fetch(:content_index),
             delta: string_value(event_patch[:delta]),
-            signature: string_value(event_patch[:signature])
+            signature: string_value(event_patch[:signature]),
+            partial:
           )
         when :text_start, :text_delta, :text_end, :tool_delta, :tool_end
           AssistantStreamEvent.new(
             type:,
             content_index: event_patch.fetch(:content_index),
-            delta: string_value(event_patch[:delta])
+            delta: string_value(event_patch[:delta]),
+            partial:
           )
         else
           raise ArgumentError, "Unsupported normalized stream event type: #{type.inspect}"
@@ -245,6 +250,14 @@ module LlmGateway
           end
         when :message_end
         end
+      end
+
+      def empty_partial
+        PartialAssistantMessage.new
+      end
+
+      def partial_message
+        PartialAssistantMessage.new(result)
       end
 
       def serialized_blocks

--- a/lib/llm_gateway/adapters/structs.rb
+++ b/lib/llm_gateway/adapters/structs.rb
@@ -9,35 +9,6 @@ class BaseStruct < Dry::Struct
   transform_keys(&:to_sym)
 end
 
-class AssistantStreamEvent < BaseStruct
-  EventType = Types::Coercible::Symbol.enum(:text_start, :text_delta, :text_end, :tool_start, :tool_delta, :tool_end, :reasoning_start, :reasoning_delta, :reasoning_end)
-
-  attribute :type, EventType
-  attribute :delta, Types::Coercible::String.default { "" }
-  attribute :content_index, Types::Integer
-end
-
-
-class AssistantToolStartEvent < AssistantStreamEvent
-  attribute :id, Types::String
-  attribute :name, Types::String
-  attribute :content_index, Types::Integer
-end
-
-
-class AssistantStreamReasoningEvent < AssistantStreamEvent
-  attribute :signature, Types::Coercible::String.default { "" }
-  attribute :content_index, Types::Integer
-end
-
-class AssistantStreamMessageEvent < BaseStruct
-  EventType = Types::Coercible::Symbol.enum(:message_start, :message_delta, :message_end)
-
-  attribute :type, EventType
-  attribute :delta, Types::Coercible::Hash.default { {} }
-  attribute :usage_increment, Types::Coercible::Hash.default { {} }
-end
-
 class TextContent < BaseStruct
   attribute :type, Types::String.enum("text")
   attribute :text, Types::String
@@ -87,12 +58,79 @@ class ToolResult < BaseStruct
   attribute :content, Types::String
 end
 
-class AssistantMessage < BaseStruct
+class PartialAssistantMessage < BaseStruct
   ContentBlock =
     Types.Instance(TextContent) |
     Types.Instance(ReasoningContent) |
     Types.Instance(ToolCall)
 
+  attribute? :id, Types::String.optional
+  attribute? :model, Types::String.optional
+  attribute? :usage, Types::Hash.optional
+  attribute? :role, Types::String.enum("assistant").optional
+  attribute? :stop_reason, Types::String.enum("stop", "length", "tool_use", "toolUse", "error", "aborted").optional
+  attribute? :content, Types::Array.of(ContentBlock).optional
+
+  def self.new(attributes = {})
+    attrs = attributes.to_h.transform_keys(&:to_sym)
+    attrs[:content] = Array(attrs[:content]).map { |block| build_content_block(block) } if attrs.key?(:content)
+    super(attrs)
+  end
+
+  def self.build_content_block(block)
+    return block if block.is_a?(TextContent) || block.is_a?(ReasoningContent) || block.is_a?(ToolCall)
+
+    case block[:type] || block["type"]
+    when "text"
+      TextContent.new(block)
+    when "reasoning"
+      ReasoningContent.new(block)
+    when "thinking"
+      ReasoningContent.new(
+        type: "reasoning",
+        reasoning: block[:thinking] || block["thinking"] || block[:reasoning] || block["reasoning"],
+        signature: block[:signature] || block["signature"]
+      )
+    when "tool_use"
+      ToolCall.new(block)
+    else
+      raise ArgumentError, "Unsupported content block type: #{block[:type] || block['type']}"
+    end
+  end
+
+  private_class_method :build_content_block
+end
+
+class AssistantStreamEvent < BaseStruct
+  EventType = Types::Coercible::Symbol.enum(:text_start, :text_delta, :text_end, :tool_start, :tool_delta, :tool_end, :reasoning_start, :reasoning_delta, :reasoning_end)
+
+  attribute :type, EventType
+  attribute :delta, Types::Coercible::String.default { "" }
+  attribute :content_index, Types::Integer
+  attribute :partial, Types.Instance(PartialAssistantMessage)
+end
+
+class AssistantToolStartEvent < AssistantStreamEvent
+  attribute :id, Types::String
+  attribute :name, Types::String
+  attribute :content_index, Types::Integer
+end
+
+class AssistantStreamReasoningEvent < AssistantStreamEvent
+  attribute :signature, Types::Coercible::String.default { "" }
+  attribute :content_index, Types::Integer
+end
+
+class AssistantStreamMessageEvent < BaseStruct
+  EventType = Types::Coercible::Symbol.enum(:message_start, :message_delta, :message_end)
+
+  attribute :type, EventType
+  attribute :delta, Types::Coercible::Hash.default { {} }
+  attribute :usage_increment, Types::Coercible::Hash.default { {} }
+  attribute :partial, Types.Instance(PartialAssistantMessage)
+end
+
+class AssistantMessage < PartialAssistantMessage
   attribute :id, Types::String
   attribute :model, Types::String
   attribute :usage, Types::Hash
@@ -102,12 +140,6 @@ class AssistantMessage < BaseStruct
   attribute :api, Types::String
   attribute? :error_message, Types::String.optional
   attribute :content, Types::Array.of(ContentBlock)
-
-  def self.new(attributes)
-    attrs = attributes.to_h.transform_keys(&:to_sym)
-    attrs[:content] = Array(attrs[:content]).map { |block| build_content_block(block) }
-    super(attrs)
-  end
 
   def to_h
     result = {
@@ -123,23 +155,4 @@ class AssistantMessage < BaseStruct
     result[:error_message] = error_message unless error_message.nil?
     result
   end
-
-  def self.build_content_block(block)
-    return block if block.is_a?(TextContent) || block.is_a?(ReasoningContent) || block.is_a?(ToolCall)
-
-    case block[:type] || block["type"]
-    when "text"
-      TextContent.new(block)
-    when "reasoning"
-      ReasoningContent.new(block)
-    when "thinking"
-      ReasoningContent.new(type: "reasoning", reasoning: block[:thinking] || block["thinking"] || block[:reasoning] || block["reasoning"], signature: block[:signature] || block["signature"])
-    when "tool_use"
-      ToolCall.new(block)
-    else
-      raise ArgumentError, "Unsupported content block type: #{block[:type] || block['type']}"
-    end
-  end
-
-  private_class_method :build_content_block
 end

--- a/test/unit/normalized_stream_accumulator_partial_test.rb
+++ b/test/unit/normalized_stream_accumulator_partial_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class NormalizedStreamAccumulatorPartialTest < Test
+  test "emitted events include accumulated partial assistant message" do
+    accumulator = LlmGateway::Adapters::NormalizedStreamAccumulator.new
+    events = []
+
+    [
+      { type: :message_start, delta: { id: "msg_1", model: "test-model", role: "assistant" }, usage_increment: { input_tokens: 3 } },
+      { type: :text_start, delta: "hel" },
+      { type: :text_delta, delta: "lo" },
+      { type: :message_delta, delta: { stop_reason: "stop" }, usage_increment: { output_tokens: 2 } },
+      { type: :text_end },
+      { type: :message_end }
+    ].each do |patch|
+      accumulator.push(patch) { |event| events << event }
+    end
+
+    assert(events.all? { |event| event.partial.is_a?(PartialAssistantMessage) })
+    assert_equal "msg_1", events[0].partial.id
+    assert_equal "hel", events[1].partial.content[0].text
+    assert_equal "hello", events[2].partial.content[0].text
+    assert_equal "stop", events[3].partial.stop_reason
+    assert_equal 2, events[3].partial.usage[:output_tokens]
+
+    final_partial = events.last.partial
+    assert_equal accumulator.result[:id], final_partial.id
+    assert_equal accumulator.result[:model], final_partial.model
+    assert_equal accumulator.result[:usage], final_partial.usage
+    assert_equal accumulator.result[:stop_reason], final_partial.stop_reason
+    assert_equal accumulator.result[:content], final_partial.content.map(&:to_h)
+  end
+
+  test "partial assistant message allows incomplete messages but assistant message does not" do
+    partial = PartialAssistantMessage.new(model: "test-model")
+
+    assert_equal "test-model", partial.model
+    assert_raises(Dry::Struct::Error) { AssistantMessage.new(model: "test-model") }
+  end
+end


### PR DESCRIPTION
# Goal
Add partial message data to streaming events so consumers can access incremental message state during streams.

# Changes made to achieve the goal
Update streaming event handling to include partial message information in emitted events and keep related behavior consistent across the gateway.

> read the commit messages for more details