### PR TITLE
Improve token normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ End events include helpers for the finalized current content block:
 - `event.reasoning` for `:reasoning_end`
 - `event.tool_call` / `event.tool` for `:tool_end`
 
-Usage counters are normalized as `:input`, `:cache_write`, `:cache_read`, and `:output`.
+Usage counters are normalized as `:input`, `:cache_write`, `:cache_read`, `:output`, and `:total`. `:total` is the sum of all input-side buckets plus output.
 
 ### Stream API without handling events (final result only)
 
@@ -413,7 +413,7 @@ result = adapter.stream(
 )
 
 puts "stop_reason: #{result.stop_reason}"
-puts "usage: #{result.usage.inspect}" # normalized keys: :input, :cache_write, :cache_read, :output
+puts "usage: #{result.usage.inspect}" # normalized keys: :input, :cache_write, :cache_read, :output, :total
 
 result.content.each do |block|
   case block.type
@@ -461,7 +461,7 @@ puts "Final stop_reason: #{result.stop_reason}"
   - fields: `reasoning` and optional `signature`
 - Usage accounting:
   - normalized in `result.usage` when provided by the upstream API
-  - keys are `:input`, `:cache_write`, `:cache_read`, and `:output`
+  - keys are `:input`, `:cache_write`, `:cache_read`, `:output`, and `:total`
 
 In practice this means you can:
 - listen to `:reasoning_*` stream event variants, and

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ response = adapter.stream(transcript, tools: tools, model: "gpt-5.4", reasoning:
   when :message_start
     puts "\n[message_start] #{event.delta.inspect}"
   when :message_delta
-    puts "\n[message_delta] #{event.delta.inspect} usage+=#{event.usage_increment.inspect}"
+    puts "\n[message_delta] #{event.delta.inspect} usage=#{event.usage.inspect}"
   when :message_end
     puts "\n[message_end] final_id=#{event.message.id} stop_reason=#{event.message.stop_reason}"
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ End events include helpers for the finalized current content block:
 - `event.reasoning` for `:reasoning_end`
 - `event.tool_call` / `event.tool` for `:tool_end`
 
-Usage counters are normalized as `:input`, `:cache_write`, `:cache_read`, `:output`, and `:total`. `:total` is the sum of all input-side buckets plus output.
+Usage counters are normalized as `:input`, `:cache_write`, `:cache_read`, `:output`, and `:total`. `:total` is the sum of all input-side buckets plus output. `usage[:raw]` contains the original provider usage/token payload.
 
 ### Stream API without handling events (final result only)
 
@@ -413,7 +413,7 @@ result = adapter.stream(
 )
 
 puts "stop_reason: #{result.stop_reason}"
-puts "usage: #{result.usage.inspect}" # normalized keys: :input, :cache_write, :cache_read, :output, :total
+puts "usage: #{result.usage.inspect}" # normalized keys: :input, :cache_write, :cache_read, :output, :total, :raw
 
 result.content.each do |block|
   case block.type
@@ -461,7 +461,7 @@ puts "Final stop_reason: #{result.stop_reason}"
   - fields: `reasoning` and optional `signature`
 - Usage accounting:
   - normalized in `result.usage` when provided by the upstream API
-  - keys are `:input`, `:cache_write`, `:cache_read`, `:output`, and `:total`
+  - keys are `:input`, `:cache_write`, `:cache_read`, `:output`, `:total`, and `:raw`
 
 In practice this means you can:
 - listen to `:reasoning_*` stream event variants, and

--- a/docs/migration_guide_0.6.0.md
+++ b/docs/migration_guide_0.6.0.md
@@ -277,7 +277,7 @@ end
 
 ## 8. Update usage accounting keys
 
-Normalized `AssistantMessage#usage`, `event.partial.usage`, and `event.usage_increment` now use provider-independent concise keys:
+Normalized `AssistantMessage#usage` and final stream `event.usage` patches now use provider-independent concise keys:
 
 | 0.5.x key | 0.6.0 key |
 |---|---|
@@ -330,11 +330,11 @@ mapper = MyStreamMapper.new(provider: "openai", api: "responses")
 
 `Adapter#stream` passes these values automatically when it instantiates the configured mapper, but direct mapper construction and custom initializers must accept/pass these keywords.
 
-Custom mappers must also push a final normalized end patch. Use the normalized usage keys shown above for `usage_increment`.
+Custom mappers must also push a final normalized end patch. Use the normalized usage keys shown above for final `usage`.
 
 ```ruby
 push_patches([
-  { type: :message_delta, delta: { stop_reason: "stop" }, usage_increment: { output: 12 } },
+  { type: :message_delta, delta: { stop_reason: "stop" }, usage: { output: 12 } },
   { type: :message_end }
 ], &block)
 ```

--- a/docs/migration_guide_0.6.0.md
+++ b/docs/migration_guide_0.6.0.md
@@ -14,7 +14,7 @@ This guide covers user-facing changes between `v0.5.0` and the latest commit on 
 - The `client.model_key` reader was removed; track the selected model at the call site or read it from returned messages.
 - Streaming events now expose accumulated partial messages during the stream, while `:message_end` exposes the final message through `event.message`.
 - Non-final stream event hashes now include `partial`; normal stream consumers are unaffected, but strict `event.to_h` snapshots/comparisons may need updates.
-- Normalized usage counters were renamed to concise keys: `:input`, `:cache_write`, `:cache_read`, and `:output`; `:reasoning_tokens` was removed.
+- Normalized usage counters were renamed to concise keys: `:input`, `:cache_write`, `:cache_read`, `:output`, and `:total`; `:reasoning_tokens` was removed.
 - Streamed assistant messages now include `timestamp` as Unix milliseconds.
 - Custom stream mappers must initialize with provider/API metadata and emit a final `:message_end` patch.
 
@@ -285,6 +285,7 @@ Normalized `AssistantMessage#usage` and final stream `event.usage` patches now u
 | `:cache_creation_input_tokens` | `:cache_write` |
 | `:cache_read_input_tokens` | `:cache_read` |
 | `:output_tokens` | `:output` |
+| computed normalized total | `:total` |
 | `:reasoning_tokens` | removed |
 
 `reasoning_tokens` was removed because providers expose and calculate reasoning token counts inconsistently. Use the streamed/final `ReasoningContent` blocks for reasoning text, and treat usage as the normalized token buckets above.
@@ -301,7 +302,7 @@ result.usage[:cache_read]
 result.usage[:output]
 ```
 
-When checking cache behavior, use `usage[:cache_read]` and `usage[:cache_write]`.
+When checking cache behavior, use `usage[:cache_read]` and `usage[:cache_write]`. `usage[:total]` is computed as `input + cache_write + cache_read + output`.
 
 ## 9. Account for timestamps on streamed messages
 
@@ -377,7 +378,7 @@ If your tests or application code compare full `event.to_h` hashes or snapshot s
 - [ ] Replace `Prompt.new("model-key")` model lookup usage with explicit provider/model configuration.
 - [ ] Replace custom `Prompt#post` usage with `Prompt#stream`.
 - [ ] Update stream callbacks to read `event.message` for `:message_end` and `event.partial` only for non-final events.
-- [ ] Rename normalized usage lookups to `:input`, `:cache_write`, `:cache_read`, and `:output`; remove `:reasoning_tokens` handling.
+- [ ] Rename normalized usage lookups to `:input`, `:cache_write`, `:cache_read`, `:output`, and `:total`; remove `:reasoning_tokens` handling.
 - [ ] Include/read `timestamp` on streamed partial and final assistant messages where you construct or persist those objects.
 - [ ] Update custom stream mappers to accept `provider:` / `api:`, emit normalized usage keys, and emit `{ type: :message_end }`.
 - [ ] For cross-provider handoffs, pass the target `model:` explicitly.

--- a/docs/migration_guide_0.6.0.md
+++ b/docs/migration_guide_0.6.0.md
@@ -277,7 +277,7 @@ end
 
 ## 8. Update usage accounting keys
 
-Normalized `AssistantMessage#usage` and final stream `event.usage` patches now use provider-independent concise keys:
+Normalized `AssistantMessage#usage` and final stream `event.usage` patches now use provider-independent concise keys plus `:raw` for the original provider usage/token payload:
 
 | 0.5.x key | 0.6.0 key |
 |---|---|
@@ -286,6 +286,7 @@ Normalized `AssistantMessage#usage` and final stream `event.usage` patches now u
 | `:cache_read_input_tokens` | `:cache_read` |
 | `:output_tokens` | `:output` |
 | computed normalized total | `:total` |
+| original provider usage payload | `:raw` |
 | `:reasoning_tokens` | removed |
 
 `reasoning_tokens` was removed because providers expose and calculate reasoning token counts inconsistently. Use the streamed/final `ReasoningContent` blocks for reasoning text, and treat usage as the normalized token buckets above.
@@ -302,7 +303,7 @@ result.usage[:cache_read]
 result.usage[:output]
 ```
 
-When checking cache behavior, use `usage[:cache_read]` and `usage[:cache_write]`. `usage[:total]` is computed as `input + cache_write + cache_read + output`.
+When checking cache behavior, use `usage[:cache_read]` and `usage[:cache_write]`. `usage[:total]` is computed as `input + cache_write + cache_read + output`. Use `usage[:raw]` when you need provider-specific token fields that are not part of the normalized counters.
 
 ## 9. Account for timestamps on streamed messages
 
@@ -378,7 +379,7 @@ If your tests or application code compare full `event.to_h` hashes or snapshot s
 - [ ] Replace `Prompt.new("model-key")` model lookup usage with explicit provider/model configuration.
 - [ ] Replace custom `Prompt#post` usage with `Prompt#stream`.
 - [ ] Update stream callbacks to read `event.message` for `:message_end` and `event.partial` only for non-final events.
-- [ ] Rename normalized usage lookups to `:input`, `:cache_write`, `:cache_read`, `:output`, and `:total`; remove `:reasoning_tokens` handling.
+- [ ] Rename normalized usage lookups to `:input`, `:cache_write`, `:cache_read`, `:output`, and `:total`; use `:raw` for provider-specific token fields; remove `:reasoning_tokens` handling.
 - [ ] Include/read `timestamp` on streamed partial and final assistant messages where you construct or persist those objects.
 - [ ] Update custom stream mappers to accept `provider:` / `api:`, emit normalized usage keys, and emit `{ type: :message_end }`.
 - [ ] For cross-provider handoffs, pass the target `model:` explicitly.

--- a/lib/llm_gateway/adapters/anthropic/stream_mapper.rb
+++ b/lib/llm_gateway/adapters/anthropic/stream_mapper.rb
@@ -80,11 +80,17 @@ module LlmGateway
         def normalized_usage(usage)
           usage = symbolize_keys(usage)
 
+          input = token_count(usage[:input_tokens])
+          cache_write = token_count(usage[:cache_creation_input_tokens])
+          cache_read = token_count(usage[:cache_read_input_tokens])
+          output = token_count(usage[:output_tokens])
+
           {
-            input: token_count(usage[:input_tokens]),
-            cache_write: token_count(usage[:cache_creation_input_tokens]),
-            cache_read: token_count(usage[:cache_read_input_tokens]),
-            output: token_count(usage[:output_tokens])
+            input:,
+            cache_write:,
+            cache_read:,
+            output:,
+            total: input + cache_write + cache_read + output
           }
         end
 

--- a/lib/llm_gateway/adapters/anthropic/stream_mapper.rb
+++ b/lib/llm_gateway/adapters/anthropic/stream_mapper.rb
@@ -90,7 +90,8 @@ module LlmGateway
             cache_write:,
             cache_read:,
             output:,
-            total: input + cache_write + cache_read + output
+            total: input + cache_write + cache_read + output,
+            raw: usage
           }
         end
 

--- a/lib/llm_gateway/adapters/anthropic/stream_mapper.rb
+++ b/lib/llm_gateway/adapters/anthropic/stream_mapper.rb
@@ -14,9 +14,7 @@ module LlmGateway
               model: chunk.dig(:data, :message, :model),
               role: chunk.dig(:data, :message, :role)
             }
-            usage_increment = normalized_usage_increment(chunk.dig(:data, :message, :usage) || {})
-
-            accumulator.push({ type: :message_start, usage_increment:, delta: }, &block)
+            accumulator.push({ type: :message_start, delta: }, &block)
           when "content_block_start"
             content_block = chunk.dig(:data, :content_block) || {}
             @current_content_block_type = content_block[:type]
@@ -61,11 +59,14 @@ module LlmGateway
             end
             @current_content_block_type = nil
           when "message_delta"
-            delta = normalize_message_delta(chunk.dig(:data, :delta) || {})
-            usage_increment = normalized_usage_increment(chunk.dig(:data, :usage) || {})
+            data = chunk[:data] || {}
+            delta = normalize_message_delta(data[:delta] || {})
+            patch = { type: :message_delta, delta: }
+            patch[:usage] = normalized_usage(data[:usage]) if data.key?(:usage)
 
-            accumulator.push({ type: :message_delta, usage_increment:, delta: }, &block)
+            accumulator.push(patch, &block)
           when "message_stop"
+
             accumulator.push({ type: :message_end }, &block)
           when "ping"
             nil
@@ -75,12 +76,6 @@ module LlmGateway
         end
 
         private
-
-        def normalized_usage_increment(usage)
-          normalized_usage(usage).each_with_object({}) do |(key, value), increment|
-            increment[key] = [ value - accumulator.usage_hash.fetch(key, 0), 0 ].max
-          end
-        end
 
         def normalized_usage(usage)
           usage = symbolize_keys(usage)

--- a/lib/llm_gateway/adapters/normalized_stream_accumulator.rb
+++ b/lib/llm_gateway/adapters/normalized_stream_accumulator.rb
@@ -22,8 +22,8 @@ module LlmGateway
       #
       # Accepted event shapes:
       #
-      #   { type: :message_start, delta: { id: "...", model: "...", role: "assistant", timestamp: 1716650000000 }, usage_increment: { ... } }
-      #   { type: :message_delta, delta: { stop_reason: "stop" }, usage_increment: { ... } }
+      #   { type: :message_start, delta: { id: "...", model: "...", role: "assistant", timestamp: 1716650000000 } }
+      #   { type: :message_delta, delta: { stop_reason: "stop" }, usage: { output: 2 } }
       #   { type: :message_end }
       #
       #   { type: :text_start, delta: "hi" }
@@ -52,6 +52,13 @@ module LlmGateway
       attr_accessor :blocks, :message_hash, :usage_hash
       attr_reader :active_block_type, :final_message
 
+      DEFAULT_USAGE = {
+        input: 0,
+        cache_write: 0,
+        cache_read: 0,
+        output: 0
+      }.freeze
+
       BLOCK_EVENT_TRANSITIONS = {
         text_start: { block_type: :text, phase: :start },
         text_delta: { block_type: :text, phase: :delta },
@@ -68,12 +75,7 @@ module LlmGateway
         @provider = provider
         @api = api
         @message_hash = {}
-        @usage_hash = {
-          input: 0,
-          cache_write: 0,
-          cache_read: 0,
-          output: 0
-        }
+        @usage_hash = DEFAULT_USAGE.dup
         @blocks = []
         @next_content_index = 0
         @active_block_type = nil
@@ -189,10 +191,13 @@ module LlmGateway
 
         case type
         when :message_start, :message_delta
+          delta = symbolize_keys(event_patch[:delta] || {})
+          usage = symbolize_keys(event_patch[:usage] || delta.delete(:usage) || {})
+
           AssistantStreamMessageEvent.new(
             type:,
-            delta: symbolize_keys(event_patch[:delta] || {}),
-            usage_increment: symbolize_keys(event_patch[:usage_increment] || {}),
+            delta:,
+            usage:,
             partial:
           )
         when :tool_start
@@ -247,9 +252,6 @@ module LlmGateway
           blocks[event.content_index][:input] += event.delta
         when :message_start
           message_hash.merge!(event.delta)
-          usage_hash.each_key do |key|
-            usage_hash[key] += event.usage_increment.fetch(key, 0)
-          end
         when :reasoning_start
           blocks[event.content_index] = {
             type: "reasoning",
@@ -263,9 +265,7 @@ module LlmGateway
           blocks[event.content_index][:signature] += event.signature
         when :message_delta
           message_hash.merge!(event.delta)
-          usage_hash.each_key do |key|
-            usage_hash[key] += event.usage_increment.fetch(key, 0)
-          end
+          assign_usage(event.usage) unless event.usage.empty?
         end
       end
 
@@ -274,7 +274,21 @@ module LlmGateway
       end
 
       def partial_message
-        PartialAssistantMessage.new(result)
+        PartialAssistantMessage.new(partial_result)
+      end
+
+      def partial_result
+        ensure_timestamp!
+
+        message_hash.merge(
+          timestamp: @timestamp,
+          content: serialized_blocks
+        )
+      end
+
+      def assign_usage(usage)
+        normalized_usage = symbolize_keys(usage)
+        @usage_hash = DEFAULT_USAGE.merge(normalized_usage.slice(*DEFAULT_USAGE.keys))
       end
 
       def serialized_blocks

--- a/lib/llm_gateway/adapters/normalized_stream_accumulator.rb
+++ b/lib/llm_gateway/adapters/normalized_stream_accumulator.rb
@@ -56,7 +56,8 @@ module LlmGateway
         input: 0,
         cache_write: 0,
         cache_read: 0,
-        output: 0
+        output: 0,
+        total: 0
       }.freeze
 
       BLOCK_EVENT_TRANSITIONS = {
@@ -192,7 +193,8 @@ module LlmGateway
         case type
         when :message_start, :message_delta
           delta = symbolize_keys(event_patch[:delta] || {})
-          usage = symbolize_keys(event_patch[:usage] || delta.delete(:usage) || {})
+          raw_usage = event_patch[:usage] || delta.delete(:usage) || {}
+          usage = raw_usage.empty? ? {} : normalized_usage(raw_usage)
 
           AssistantStreamMessageEvent.new(
             type:,
@@ -287,8 +289,13 @@ module LlmGateway
       end
 
       def assign_usage(usage)
-        normalized_usage = symbolize_keys(usage)
-        @usage_hash = DEFAULT_USAGE.merge(normalized_usage.slice(*DEFAULT_USAGE.keys))
+        @usage_hash = normalized_usage(usage)
+      end
+
+      def normalized_usage(usage)
+        usage = DEFAULT_USAGE.merge(symbolize_keys(usage).slice(*DEFAULT_USAGE.keys))
+        usage[:total] = usage[:input] + usage[:cache_write] + usage[:cache_read] + usage[:output]
+        usage
       end
 
       def serialized_blocks

--- a/lib/llm_gateway/adapters/normalized_stream_accumulator.rb
+++ b/lib/llm_gateway/adapters/normalized_stream_accumulator.rb
@@ -57,7 +57,8 @@ module LlmGateway
         cache_write: 0,
         cache_read: 0,
         output: 0,
-        total: 0
+        total: 0,
+        raw: {}
       }.freeze
 
       BLOCK_EVENT_TRANSITIONS = {
@@ -76,7 +77,7 @@ module LlmGateway
         @provider = provider
         @api = api
         @message_hash = {}
-        @usage_hash = DEFAULT_USAGE.dup
+        @usage_hash = default_usage
         @blocks = []
         @next_content_index = 0
         @active_block_type = nil
@@ -293,9 +294,14 @@ module LlmGateway
       end
 
       def normalized_usage(usage)
-        usage = DEFAULT_USAGE.merge(symbolize_keys(usage).slice(*DEFAULT_USAGE.keys))
+        usage = default_usage.merge(symbolize_keys(usage).slice(*DEFAULT_USAGE.keys))
         usage[:total] = usage[:input] + usage[:cache_write] + usage[:cache_read] + usage[:output]
+        usage[:raw] ||= {}
         usage
+      end
+
+      def default_usage
+        DEFAULT_USAGE.merge(raw: {})
       end
 
       def serialized_blocks

--- a/lib/llm_gateway/adapters/openai/chat_completions/stream_mapper.rb
+++ b/lib/llm_gateway/adapters/openai/chat_completions/stream_mapper.rb
@@ -235,7 +235,8 @@ module LlmGateway
               cache_write:,
               cache_read:,
               output:,
-              total: input + cache_write + cache_read + output
+              total: input + cache_write + cache_read + output,
+              raw: usage
             }
           end
 

--- a/lib/llm_gateway/adapters/openai/chat_completions/stream_mapper.rb
+++ b/lib/llm_gateway/adapters/openai/chat_completions/stream_mapper.rb
@@ -227,12 +227,15 @@ module LlmGateway
               usage[:cache_write_tokens]
             )
             prompt_tokens = token_count(usage[:prompt_tokens])
+            input = [ prompt_tokens - cache_read - cache_write, 0 ].max
+            output = token_count(usage[:completion_tokens])
 
             {
-              input: [ prompt_tokens - cache_read - cache_write, 0 ].max,
+              input:,
               cache_write:,
               cache_read:,
-              output: token_count(usage[:completion_tokens])
+              output:,
+              total: input + cache_write + cache_read + output
             }
           end
 

--- a/lib/llm_gateway/adapters/openai/chat_completions/stream_mapper.rb
+++ b/lib/llm_gateway/adapters/openai/chat_completions/stream_mapper.rb
@@ -94,8 +94,7 @@ module LlmGateway
                   model: data[:model],
                   role: delta[:role] || "assistant",
                   timestamp: timestamp_milliseconds(data[:created])
-                }.compact,
-                usage_increment: {}
+                }.compact
               }
             ]
           end
@@ -199,24 +198,25 @@ module LlmGateway
               *close_active_block_patches(active_block_type:),
               {
                 type: :message_delta,
-                delta: { stop_reason: normalize_stop_reason(finish_reason) },
-                usage_increment: {}
+                delta: { stop_reason: normalize_stop_reason(finish_reason) }
               }
             ]
           end
 
           def final_usage_patches(data)
+            patch = {
+              type: :message_delta,
+              delta: {}
+            }
+            patch[:usage] = usage(data) if data.key?(:usage)
+
             [
-              {
-                type: accumulator.message_hash.empty? ? :message_start : :message_delta,
-                delta: {},
-                usage_increment: usage_increment(data)
-              },
+              patch,
               { type: :message_end }
             ]
           end
 
-          def usage_increment(data)
+          def usage(data)
             usage = data[:usage] || {}
             cache_read = token_count(
               usage.dig(:prompt_tokens_details, :cached_tokens),

--- a/lib/llm_gateway/adapters/openai/responses/stream_mapper.rb
+++ b/lib/llm_gateway/adapters/openai/responses/stream_mapper.rb
@@ -131,12 +131,15 @@ module LlmGateway
               usage[:cache_write_tokens]
             )
             input_tokens = token_count(usage[:input_tokens])
+            input = [ input_tokens - cache_read - cache_write, 0 ].max
+            output = token_count(usage[:output_tokens])
 
             {
-              input: [ input_tokens - cache_read - cache_write, 0 ].max,
+              input:,
               cache_write:,
               cache_read:,
-              output: token_count(usage[:output_tokens])
+              output:,
+              total: input + cache_write + cache_read + output
             }
           end
 

--- a/lib/llm_gateway/adapters/openai/responses/stream_mapper.rb
+++ b/lib/llm_gateway/adapters/openai/responses/stream_mapper.rb
@@ -139,7 +139,8 @@ module LlmGateway
               cache_write:,
               cache_read:,
               output:,
-              total: input + cache_write + cache_read + output
+              total: input + cache_write + cache_read + output,
+              raw: usage
             }
           end
 

--- a/lib/llm_gateway/adapters/openai/responses/stream_mapper.rb
+++ b/lib/llm_gateway/adapters/openai/responses/stream_mapper.rb
@@ -57,8 +57,7 @@ module LlmGateway
                   model: response[:model],
                   role: "assistant",
                   timestamp: timestamp_milliseconds(response[:created_at])
-                }.compact,
-                usage_increment: {}
+                }.compact
               }
             ]
           end
@@ -73,8 +72,7 @@ module LlmGateway
               [
                 {
                   type: :message_start,
-                  delta: { role: item[:role] || "assistant" },
-                  usage_increment: {}
+                  delta: { role: item[:role] || "assistant" }
                 }
               ]
             when "function_call"
@@ -107,24 +105,25 @@ module LlmGateway
 
           def response_completed_patches(response)
             response ||= {}
+            patch = {
+              type: :message_delta,
+              delta: {
+                id: response[:id],
+                model: response[:model],
+                role: "assistant",
+                timestamp: timestamp_milliseconds(response[:created_at]),
+                stop_reason: stop_reason_for(response)
+              }.compact
+            }
+            patch[:usage] = usage(response) if response.key?(:usage)
 
             [
-              {
-                type: accumulator.message_hash.empty? ? :message_start : :message_delta,
-                delta: {
-                  id: response[:id],
-                  model: response[:model],
-                  role: "assistant",
-                  timestamp: timestamp_milliseconds(response[:created_at]),
-                  stop_reason: stop_reason_for(response)
-                }.compact,
-                usage_increment: usage_increment(response)
-              },
+              patch,
               { type: :message_end }
             ]
           end
 
-          def usage_increment(response)
+          def usage(response)
             usage = response[:usage] || {}
             cache_read = token_count(usage.dig(:input_tokens_details, :cached_tokens))
             cache_write = token_count(

--- a/lib/llm_gateway/adapters/structs.rb
+++ b/lib/llm_gateway/adapters/structs.rb
@@ -66,7 +66,6 @@ class PartialAssistantMessage < BaseStruct
 
   attribute? :id, Types::String.optional
   attribute? :model, Types::String.optional
-  attribute? :usage, Types::Hash.optional
   attribute? :role, Types::String.enum("assistant").optional
   attribute :timestamp, Types::Integer
   attribute? :stop_reason, Types::String.enum("stop", "length", "tool_use", "toolUse", "error", "aborted").optional
@@ -186,7 +185,7 @@ class AssistantStreamMessageEvent < BaseStruct
 
   attribute :type, EventType
   attribute :delta, Types::Coercible::Hash.default { {} }
-  attribute :usage_increment, Types::Coercible::Hash.default { {} }
+  attribute :usage, Types::Coercible::Hash.default { {} }
   attribute :partial, Types.Instance(PartialAssistantMessage)
 end
 

--- a/test/fixtures/handoff/stream_image_test/anthropic_apikey_messages_claude-sonnet-4-20250514.json
+++ b/test/fixtures/handoff/stream_image_test/anthropic_apikey_messages_claude-sonnet-4-20250514.json
@@ -20,7 +20,8 @@
       "input": 121,
       "cache_write": 0,
       "cache_read": 0,
-      "output": 25
+      "output": 25,
+      "total": 146
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_image_test/anthropic_apikey_messages_claude-sonnet-4-20250514.json
+++ b/test/fixtures/handoff/stream_image_test/anthropic_apikey_messages_claude-sonnet-4-20250514.json
@@ -21,7 +21,13 @@
       "cache_write": 0,
       "cache_read": 0,
       "output": 25,
-      "total": 146
+      "total": 146,
+      "raw": {
+        "input_tokens": 121,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "output_tokens": 25
+      }
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_image_test/anthropic_oauth_messages_claude-sonnet-4-20250514.json
+++ b/test/fixtures/handoff/stream_image_test/anthropic_oauth_messages_claude-sonnet-4-20250514.json
@@ -20,7 +20,8 @@
       "input": 135,
       "cache_write": 0,
       "cache_read": 0,
-      "output": 25
+      "output": 25,
+      "total": 160
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_image_test/anthropic_oauth_messages_claude-sonnet-4-20250514.json
+++ b/test/fixtures/handoff/stream_image_test/anthropic_oauth_messages_claude-sonnet-4-20250514.json
@@ -21,7 +21,13 @@
       "cache_write": 0,
       "cache_read": 0,
       "output": 25,
-      "total": 160
+      "total": 160,
+      "raw": {
+        "input_tokens": 135,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "output_tokens": 25
+      }
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_image_test/groq_completions_meta-llama_llama-4-scout-17b-16e-instruct.json
+++ b/test/fixtures/handoff/stream_image_test/groq_completions_meta-llama_llama-4-scout-17b-16e-instruct.json
@@ -21,7 +21,16 @@
       "cache_write": 0,
       "cache_read": 0,
       "output": 32,
-      "total": 241
+      "total": 241,
+      "raw": {
+        "queue_time": 0.073747082,
+        "prompt_tokens": 209,
+        "prompt_time": 0.007524811,
+        "completion_tokens": 32,
+        "completion_time": 0.073274001,
+        "total_tokens": 241,
+        "total_time": 0.080798812
+      }
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_image_test/groq_completions_meta-llama_llama-4-scout-17b-16e-instruct.json
+++ b/test/fixtures/handoff/stream_image_test/groq_completions_meta-llama_llama-4-scout-17b-16e-instruct.json
@@ -20,7 +20,8 @@
       "input": 209,
       "cache_write": 0,
       "cache_read": 0,
-      "output": 32
+      "output": 32,
+      "total": 241
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_image_test/openai_apikey_completions_gpt-5.1.json
+++ b/test/fixtures/handoff/stream_image_test/openai_apikey_completions_gpt-5.1.json
@@ -21,7 +21,22 @@
       "cache_write": 0,
       "cache_read": 0,
       "output": 19,
-      "total": 284
+      "total": 284,
+      "raw": {
+        "prompt_tokens": 265,
+        "completion_tokens": 19,
+        "total_tokens": 284,
+        "prompt_tokens_details": {
+          "cached_tokens": 0,
+          "audio_tokens": 0
+        },
+        "completion_tokens_details": {
+          "reasoning_tokens": 0,
+          "audio_tokens": 0,
+          "accepted_prediction_tokens": 0,
+          "rejected_prediction_tokens": 0
+        }
+      }
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_image_test/openai_apikey_completions_gpt-5.1.json
+++ b/test/fixtures/handoff/stream_image_test/openai_apikey_completions_gpt-5.1.json
@@ -20,7 +20,8 @@
       "input": 265,
       "cache_write": 0,
       "cache_read": 0,
-      "output": 19
+      "output": 19,
+      "total": 284
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_image_test/openai_apikey_responses_gpt-5.4.json
+++ b/test/fixtures/handoff/stream_image_test/openai_apikey_responses_gpt-5.4.json
@@ -21,7 +21,18 @@
       "cache_write": 0,
       "cache_read": 0,
       "output": 10,
-      "total": 124
+      "total": 124,
+      "raw": {
+        "input_tokens": 114,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 10,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 124
+      }
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_image_test/openai_apikey_responses_gpt-5.4.json
+++ b/test/fixtures/handoff/stream_image_test/openai_apikey_responses_gpt-5.4.json
@@ -20,7 +20,8 @@
       "input": 114,
       "cache_write": 0,
       "cache_read": 0,
-      "output": 10
+      "output": 10,
+      "total": 124
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_image_test/openai_oauth_codex_gpt-5.4.json
+++ b/test/fixtures/handoff/stream_image_test/openai_oauth_codex_gpt-5.4.json
@@ -20,7 +20,8 @@
       "input": 114,
       "cache_write": 0,
       "cache_read": 0,
-      "output": 8
+      "output": 8,
+      "total": 122
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_image_test/openai_oauth_codex_gpt-5.4.json
+++ b/test/fixtures/handoff/stream_image_test/openai_oauth_codex_gpt-5.4.json
@@ -21,7 +21,18 @@
       "cache_write": 0,
       "cache_read": 0,
       "output": 8,
-      "total": 122
+      "total": 122,
+      "raw": {
+        "input_tokens": 114,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 8,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 122
+      }
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_reasoning_test/anthropic_apikey_messages_claude-sonnet-4-20250514.json
+++ b/test/fixtures/handoff/stream_reasoning_test/anthropic_apikey_messages_claude-sonnet-4-20250514.json
@@ -15,7 +15,8 @@
       "input": 47,
       "cache_write": 0,
       "cache_read": 0,
-      "output": 782
+      "output": 782,
+      "total": 829
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_reasoning_test/anthropic_apikey_messages_claude-sonnet-4-20250514.json
+++ b/test/fixtures/handoff/stream_reasoning_test/anthropic_apikey_messages_claude-sonnet-4-20250514.json
@@ -16,7 +16,13 @@
       "cache_write": 0,
       "cache_read": 0,
       "output": 782,
-      "total": 829
+      "total": 829,
+      "raw": {
+        "input_tokens": 47,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "output_tokens": 782
+      }
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_reasoning_test/anthropic_oauth_messages_claude-sonnet-4-20250514.json
+++ b/test/fixtures/handoff/stream_reasoning_test/anthropic_oauth_messages_claude-sonnet-4-20250514.json
@@ -16,7 +16,13 @@
       "cache_write": 0,
       "cache_read": 0,
       "output": 708,
-      "total": 770
+      "total": 770,
+      "raw": {
+        "input_tokens": 62,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "output_tokens": 708
+      }
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_reasoning_test/anthropic_oauth_messages_claude-sonnet-4-20250514.json
+++ b/test/fixtures/handoff/stream_reasoning_test/anthropic_oauth_messages_claude-sonnet-4-20250514.json
@@ -15,7 +15,8 @@
       "input": 62,
       "cache_write": 0,
       "cache_read": 0,
-      "output": 708
+      "output": 708,
+      "total": 770
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_reasoning_test/groq_completions_openai_gpt-oss-120b.json
+++ b/test/fixtures/handoff/stream_reasoning_test/groq_completions_openai_gpt-oss-120b.json
@@ -16,7 +16,19 @@
       "cache_write": 0,
       "cache_read": 0,
       "output": 837,
-      "total": 918
+      "total": 918,
+      "raw": {
+        "queue_time": 0.048452189,
+        "prompt_tokens": 81,
+        "prompt_time": 0.003167066,
+        "completion_tokens": 837,
+        "completion_time": 1.755938377,
+        "total_tokens": 918,
+        "total_time": 1.7591054430000002,
+        "completion_tokens_details": {
+          "reasoning_tokens": 335
+        }
+      }
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_reasoning_test/groq_completions_openai_gpt-oss-120b.json
+++ b/test/fixtures/handoff/stream_reasoning_test/groq_completions_openai_gpt-oss-120b.json
@@ -15,7 +15,8 @@
       "input": 81,
       "cache_write": 0,
       "cache_read": 0,
-      "output": 837
+      "output": 837,
+      "total": 918
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_reasoning_test/openai_apikey_completions_gpt-5.1.json
+++ b/test/fixtures/handoff/stream_reasoning_test/openai_apikey_completions_gpt-5.1.json
@@ -16,7 +16,22 @@
       "cache_write": 0,
       "cache_read": 0,
       "output": 153,
-      "total": 169
+      "total": 169,
+      "raw": {
+        "prompt_tokens": 16,
+        "completion_tokens": 153,
+        "total_tokens": 169,
+        "prompt_tokens_details": {
+          "cached_tokens": 0,
+          "audio_tokens": 0
+        },
+        "completion_tokens_details": {
+          "reasoning_tokens": 136,
+          "audio_tokens": 0,
+          "accepted_prediction_tokens": 0,
+          "rejected_prediction_tokens": 0
+        }
+      }
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_reasoning_test/openai_apikey_completions_gpt-5.1.json
+++ b/test/fixtures/handoff/stream_reasoning_test/openai_apikey_completions_gpt-5.1.json
@@ -15,7 +15,8 @@
       "input": 16,
       "cache_write": 0,
       "cache_read": 0,
-      "output": 153
+      "output": 153,
+      "total": 169
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_reasoning_test/openai_apikey_responses_gpt-5.4.json
+++ b/test/fixtures/handoff/stream_reasoning_test/openai_apikey_responses_gpt-5.4.json
@@ -16,7 +16,18 @@
       "cache_write": 0,
       "cache_read": 0,
       "output": 95,
-      "total": 111
+      "total": 111,
+      "raw": {
+        "input_tokens": 16,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 95,
+        "output_tokens_details": {
+          "reasoning_tokens": 81
+        },
+        "total_tokens": 111
+      }
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_reasoning_test/openai_apikey_responses_gpt-5.4.json
+++ b/test/fixtures/handoff/stream_reasoning_test/openai_apikey_responses_gpt-5.4.json
@@ -15,7 +15,8 @@
       "input": 16,
       "cache_write": 0,
       "cache_read": 0,
-      "output": 95
+      "output": 95,
+      "total": 111
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_reasoning_test/openai_oauth_codex_gpt-5.4.json
+++ b/test/fixtures/handoff/stream_reasoning_test/openai_oauth_codex_gpt-5.4.json
@@ -16,7 +16,18 @@
       "cache_write": 0,
       "cache_read": 0,
       "output": 92,
-      "total": 118
+      "total": 118,
+      "raw": {
+        "input_tokens": 26,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 92,
+        "output_tokens_details": {
+          "reasoning_tokens": 79
+        },
+        "total_tokens": 118
+      }
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_reasoning_test/openai_oauth_codex_gpt-5.4.json
+++ b/test/fixtures/handoff/stream_reasoning_test/openai_oauth_codex_gpt-5.4.json
@@ -15,7 +15,8 @@
       "input": 26,
       "cache_write": 0,
       "cache_read": 0,
-      "output": 92
+      "output": 92,
+      "total": 118
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_text_test/anthropic_apikey_messages_claude-sonnet-4-20250514.json
+++ b/test/fixtures/handoff/stream_text_test/anthropic_apikey_messages_claude-sonnet-4-20250514.json
@@ -15,7 +15,8 @@
       "input": 15,
       "cache_write": 0,
       "cache_read": 0,
-      "output": 9
+      "output": 9,
+      "total": 24
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_text_test/anthropic_apikey_messages_claude-sonnet-4-20250514.json
+++ b/test/fixtures/handoff/stream_text_test/anthropic_apikey_messages_claude-sonnet-4-20250514.json
@@ -16,7 +16,13 @@
       "cache_write": 0,
       "cache_read": 0,
       "output": 9,
-      "total": 24
+      "total": 24,
+      "raw": {
+        "input_tokens": 15,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "output_tokens": 9
+      }
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_text_test/anthropic_oauth_messages_claude-sonnet-4-20250514.json
+++ b/test/fixtures/handoff/stream_text_test/anthropic_oauth_messages_claude-sonnet-4-20250514.json
@@ -16,7 +16,13 @@
       "cache_write": 0,
       "cache_read": 0,
       "output": 9,
-      "total": 38
+      "total": 38,
+      "raw": {
+        "input_tokens": 29,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "output_tokens": 9
+      }
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_text_test/anthropic_oauth_messages_claude-sonnet-4-20250514.json
+++ b/test/fixtures/handoff/stream_text_test/anthropic_oauth_messages_claude-sonnet-4-20250514.json
@@ -15,7 +15,8 @@
       "input": 29,
       "cache_write": 0,
       "cache_read": 0,
-      "output": 9
+      "output": 9,
+      "total": 38
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_text_test/groq_completions_openai_gpt-oss-120b.json
+++ b/test/fixtures/handoff/stream_text_test/groq_completions_openai_gpt-oss-120b.json
@@ -15,7 +15,8 @@
       "input": 78,
       "cache_write": 0,
       "cache_read": 0,
-      "output": 54
+      "output": 54,
+      "total": 132
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_text_test/groq_completions_openai_gpt-oss-120b.json
+++ b/test/fixtures/handoff/stream_text_test/groq_completions_openai_gpt-oss-120b.json
@@ -16,7 +16,19 @@
       "cache_write": 0,
       "cache_read": 0,
       "output": 54,
-      "total": 132
+      "total": 132,
+      "raw": {
+        "queue_time": 0.050799132,
+        "prompt_tokens": 78,
+        "prompt_time": 0.002873187,
+        "completion_tokens": 54,
+        "completion_time": 0.111673187,
+        "total_tokens": 132,
+        "total_time": 0.114546374,
+        "completion_tokens_details": {
+          "reasoning_tokens": 37
+        }
+      }
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_text_test/openai_apikey_completions_gpt-5.1.json
+++ b/test/fixtures/handoff/stream_text_test/openai_apikey_completions_gpt-5.1.json
@@ -16,7 +16,22 @@
       "cache_write": 0,
       "cache_read": 0,
       "output": 14,
-      "total": 27
+      "total": 27,
+      "raw": {
+        "prompt_tokens": 13,
+        "completion_tokens": 14,
+        "total_tokens": 27,
+        "prompt_tokens_details": {
+          "cached_tokens": 0,
+          "audio_tokens": 0
+        },
+        "completion_tokens_details": {
+          "reasoning_tokens": 0,
+          "audio_tokens": 0,
+          "accepted_prediction_tokens": 0,
+          "rejected_prediction_tokens": 0
+        }
+      }
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_text_test/openai_apikey_completions_gpt-5.1.json
+++ b/test/fixtures/handoff/stream_text_test/openai_apikey_completions_gpt-5.1.json
@@ -15,7 +15,8 @@
       "input": 13,
       "cache_write": 0,
       "cache_read": 0,
-      "output": 14
+      "output": 14,
+      "total": 27
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_text_test/openai_apikey_responses_gpt-5.4.json
+++ b/test/fixtures/handoff/stream_text_test/openai_apikey_responses_gpt-5.4.json
@@ -16,7 +16,18 @@
       "cache_write": 0,
       "cache_read": 0,
       "output": 9,
-      "total": 22
+      "total": 22,
+      "raw": {
+        "input_tokens": 13,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 9,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 22
+      }
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_text_test/openai_apikey_responses_gpt-5.4.json
+++ b/test/fixtures/handoff/stream_text_test/openai_apikey_responses_gpt-5.4.json
@@ -15,7 +15,8 @@
       "input": 13,
       "cache_write": 0,
       "cache_read": 0,
-      "output": 9
+      "output": 9,
+      "total": 22
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_text_test/openai_oauth_codex_gpt-5.4.json
+++ b/test/fixtures/handoff/stream_text_test/openai_oauth_codex_gpt-5.4.json
@@ -15,7 +15,8 @@
       "input": 23,
       "cache_write": 0,
       "cache_read": 0,
-      "output": 11
+      "output": 11,
+      "total": 34
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_text_test/openai_oauth_codex_gpt-5.4.json
+++ b/test/fixtures/handoff/stream_text_test/openai_oauth_codex_gpt-5.4.json
@@ -16,7 +16,18 @@
       "cache_write": 0,
       "cache_read": 0,
       "output": 11,
-      "total": 34
+      "total": 34,
+      "raw": {
+        "input_tokens": 23,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 11,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 34
+      }
     },
     "role": "assistant",
     "stop_reason": "stop",

--- a/test/fixtures/handoff/stream_tool_call_test/anthropic_apikey_messages_claude-sonnet-4-20250514.json
+++ b/test/fixtures/handoff/stream_tool_call_test/anthropic_apikey_messages_claude-sonnet-4-20250514.json
@@ -15,7 +15,8 @@
       "input": 457,
       "cache_write": 0,
       "cache_read": 0,
-      "output": 107
+      "output": 107,
+      "total": 564
     },
     "role": "assistant",
     "stop_reason": "tool_use",

--- a/test/fixtures/handoff/stream_tool_call_test/anthropic_apikey_messages_claude-sonnet-4-20250514.json
+++ b/test/fixtures/handoff/stream_tool_call_test/anthropic_apikey_messages_claude-sonnet-4-20250514.json
@@ -16,7 +16,13 @@
       "cache_write": 0,
       "cache_read": 0,
       "output": 107,
-      "total": 564
+      "total": 564,
+      "raw": {
+        "input_tokens": 457,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "output_tokens": 107
+      }
     },
     "role": "assistant",
     "stop_reason": "tool_use",

--- a/test/fixtures/handoff/stream_tool_call_test/anthropic_oauth_messages_claude-sonnet-4-20250514.json
+++ b/test/fixtures/handoff/stream_tool_call_test/anthropic_oauth_messages_claude-sonnet-4-20250514.json
@@ -15,7 +15,8 @@
       "input": 472,
       "cache_write": 0,
       "cache_read": 0,
-      "output": 105
+      "output": 105,
+      "total": 577
     },
     "role": "assistant",
     "stop_reason": "tool_use",

--- a/test/fixtures/handoff/stream_tool_call_test/anthropic_oauth_messages_claude-sonnet-4-20250514.json
+++ b/test/fixtures/handoff/stream_tool_call_test/anthropic_oauth_messages_claude-sonnet-4-20250514.json
@@ -16,7 +16,13 @@
       "cache_write": 0,
       "cache_read": 0,
       "output": 105,
-      "total": 577
+      "total": 577,
+      "raw": {
+        "input_tokens": 472,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "output_tokens": 105
+      }
     },
     "role": "assistant",
     "stop_reason": "tool_use",

--- a/test/fixtures/handoff/stream_tool_call_test/groq_completions_openai_gpt-oss-120b.json
+++ b/test/fixtures/handoff/stream_tool_call_test/groq_completions_openai_gpt-oss-120b.json
@@ -15,7 +15,8 @@
       "input": 167,
       "cache_write": 0,
       "cache_read": 0,
-      "output": 63
+      "output": 63,
+      "total": 230
     },
     "role": "assistant",
     "stop_reason": "tool_use",

--- a/test/fixtures/handoff/stream_tool_call_test/groq_completions_openai_gpt-oss-120b.json
+++ b/test/fixtures/handoff/stream_tool_call_test/groq_completions_openai_gpt-oss-120b.json
@@ -16,7 +16,19 @@
       "cache_write": 0,
       "cache_read": 0,
       "output": 63,
-      "total": 230
+      "total": 230,
+      "raw": {
+        "queue_time": 0.047591792,
+        "prompt_tokens": 167,
+        "prompt_time": 0.006648028,
+        "completion_tokens": 63,
+        "completion_time": 0.131126169,
+        "total_tokens": 230,
+        "total_time": 0.137774197,
+        "completion_tokens_details": {
+          "reasoning_tokens": 22
+        }
+      }
     },
     "role": "assistant",
     "stop_reason": "tool_use",

--- a/test/fixtures/handoff/stream_tool_call_test/openai_apikey_completions_gpt-5.1.json
+++ b/test/fixtures/handoff/stream_tool_call_test/openai_apikey_completions_gpt-5.1.json
@@ -15,7 +15,8 @@
       "input": 173,
       "cache_write": 0,
       "cache_read": 0,
-      "output": 31
+      "output": 31,
+      "total": 204
     },
     "role": "assistant",
     "stop_reason": "tool_use",

--- a/test/fixtures/handoff/stream_tool_call_test/openai_apikey_completions_gpt-5.1.json
+++ b/test/fixtures/handoff/stream_tool_call_test/openai_apikey_completions_gpt-5.1.json
@@ -16,7 +16,22 @@
       "cache_write": 0,
       "cache_read": 0,
       "output": 31,
-      "total": 204
+      "total": 204,
+      "raw": {
+        "prompt_tokens": 173,
+        "completion_tokens": 31,
+        "total_tokens": 204,
+        "prompt_tokens_details": {
+          "cached_tokens": 0,
+          "audio_tokens": 0
+        },
+        "completion_tokens_details": {
+          "reasoning_tokens": 0,
+          "audio_tokens": 0,
+          "accepted_prediction_tokens": 0,
+          "rejected_prediction_tokens": 0
+        }
+      }
     },
     "role": "assistant",
     "stop_reason": "tool_use",

--- a/test/fixtures/handoff/stream_tool_call_test/openai_apikey_responses_gpt-5.4.json
+++ b/test/fixtures/handoff/stream_tool_call_test/openai_apikey_responses_gpt-5.4.json
@@ -16,7 +16,18 @@
       "cache_write": 0,
       "cache_read": 0,
       "output": 26,
-      "total": 117
+      "total": 117,
+      "raw": {
+        "input_tokens": 91,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 26,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 117
+      }
     },
     "role": "assistant",
     "stop_reason": "tool_use",

--- a/test/fixtures/handoff/stream_tool_call_test/openai_apikey_responses_gpt-5.4.json
+++ b/test/fixtures/handoff/stream_tool_call_test/openai_apikey_responses_gpt-5.4.json
@@ -15,7 +15,8 @@
       "input": 91,
       "cache_write": 0,
       "cache_read": 0,
-      "output": 26
+      "output": 26,
+      "total": 117
     },
     "role": "assistant",
     "stop_reason": "tool_use",

--- a/test/fixtures/handoff/stream_tool_call_test/openai_oauth_codex_gpt-5.4.json
+++ b/test/fixtures/handoff/stream_tool_call_test/openai_oauth_codex_gpt-5.4.json
@@ -16,7 +16,18 @@
       "cache_write": 0,
       "cache_read": 0,
       "output": 26,
-      "total": 127
+      "total": 127,
+      "raw": {
+        "input_tokens": 101,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 26,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 127
+      }
     },
     "role": "assistant",
     "stop_reason": "tool_use",

--- a/test/fixtures/handoff/stream_tool_call_test/openai_oauth_codex_gpt-5.4.json
+++ b/test/fixtures/handoff/stream_tool_call_test/openai_oauth_codex_gpt-5.4.json
@@ -15,7 +15,8 @@
       "input": 101,
       "cache_write": 0,
       "cache_read": 0,
-      "output": 26
+      "output": 26,
+      "total": 127
     },
     "role": "assistant",
     "stop_reason": "tool_use",

--- a/test/unit/normalized_stream_accumulator_partial_test.rb
+++ b/test/unit/normalized_stream_accumulator_partial_test.rb
@@ -37,7 +37,7 @@ class NormalizedStreamAccumulatorPartialTest < Test
     assert_equal message_end.message.timestamp, message_end.message.to_h[:timestamp]
     assert_equal accumulator.result[:id], message_end.message.id
     assert_equal accumulator.result[:model], message_end.message.model
-    assert_equal({ input: 3, cache_write: 0, cache_read: 0, output: 2 }, message_end.message.usage)
+    assert_equal({ input: 3, cache_write: 0, cache_read: 0, output: 2, total: 5 }, message_end.message.usage)
     assert_equal accumulator.result[:usage], message_end.message.usage
     assert_equal accumulator.result[:stop_reason], message_end.message.stop_reason
     assert_equal accumulator.result[:content], message_end.message.content.map(&:to_h)
@@ -97,7 +97,7 @@ class NormalizedStreamAccumulatorPartialTest < Test
 
     assert_equal 1_716_650_000_000, events.first.partial.timestamp
     assert_equal 1_716_650_000_000, events.last.message.timestamp
-    assert_equal({ input: 0, cache_write: 0, cache_read: 0, output: 0 }, events.last.message.usage)
+    assert_equal({ input: 0, cache_write: 0, cache_read: 0, output: 0, total: 0 }, events.last.message.usage)
   end
 
   test "usage is assigned from final usage patch rather than accumulated" do
@@ -113,7 +113,24 @@ class NormalizedStreamAccumulatorPartialTest < Test
     end
 
     refute_respond_to events.first.partial, :usage
-    assert_equal({ input: 3, cache_write: 0, cache_read: 0, output: 2 }, events.last.message.usage)
+    assert_equal({ input: 3, cache_write: 0, cache_read: 0, output: 2, total: 5 }, events.last.message.usage)
+  end
+
+  test "usage total includes input cache and output tokens" do
+    accumulator = LlmGateway::Adapters::NormalizedStreamAccumulator.new(provider: "test-provider", api: "test-api")
+    events = []
+
+    [
+      { type: :message_start, delta: { id: "msg_1", model: "test-model", role: "assistant" } },
+      { type: :message_delta, delta: { stop_reason: "stop" }, usage: { input: 3, cache_write: 4, cache_read: 5, output: 6, total: 999 } },
+      { type: :message_end }
+    ].each do |patch|
+      accumulator.push(patch) { |event| events << event }
+    end
+
+    expected_usage = { input: 3, cache_write: 4, cache_read: 5, output: 6, total: 18 }
+    assert_equal expected_usage, events[1].usage
+    assert_equal expected_usage, events.last.message.usage
   end
 
   test "partial assistant message allows incomplete messages except timestamp but assistant message does not" do

--- a/test/unit/normalized_stream_accumulator_partial_test.rb
+++ b/test/unit/normalized_stream_accumulator_partial_test.rb
@@ -8,10 +8,10 @@ class NormalizedStreamAccumulatorPartialTest < Test
     events = []
 
     [
-      { type: :message_start, delta: { id: "msg_1", model: "test-model", role: "assistant" }, usage_increment: { input: 3 } },
+      { type: :message_start, delta: { id: "msg_1", model: "test-model", role: "assistant" } },
       { type: :text_start, delta: "hel" },
       { type: :text_delta, delta: "lo" },
-      { type: :message_delta, delta: { stop_reason: "stop" }, usage_increment: { output: 2 } },
+      { type: :message_delta, delta: { stop_reason: "stop" }, usage: { input: 3, output: 2 } },
       { type: :text_end },
       { type: :message_end }
     ].each do |patch|
@@ -25,7 +25,7 @@ class NormalizedStreamAccumulatorPartialTest < Test
     assert_equal "hel", events[1].partial.content[0].text
     assert_equal "hello", events[2].partial.content[0].text
     assert_equal "stop", events[3].partial.stop_reason
-    assert_equal 2, events[3].partial.usage[:output]
+    refute_respond_to events[3].partial, :usage
 
     message_end = events.last
     assert(message_end.message.is_a?(AssistantMessage))
@@ -37,6 +37,7 @@ class NormalizedStreamAccumulatorPartialTest < Test
     assert_equal message_end.message.timestamp, message_end.message.to_h[:timestamp]
     assert_equal accumulator.result[:id], message_end.message.id
     assert_equal accumulator.result[:model], message_end.message.model
+    assert_equal({ input: 3, cache_write: 0, cache_read: 0, output: 2 }, message_end.message.usage)
     assert_equal accumulator.result[:usage], message_end.message.usage
     assert_equal accumulator.result[:stop_reason], message_end.message.stop_reason
     assert_equal accumulator.result[:content], message_end.message.content.map(&:to_h)
@@ -96,6 +97,23 @@ class NormalizedStreamAccumulatorPartialTest < Test
 
     assert_equal 1_716_650_000_000, events.first.partial.timestamp
     assert_equal 1_716_650_000_000, events.last.message.timestamp
+    assert_equal({ input: 0, cache_write: 0, cache_read: 0, output: 0 }, events.last.message.usage)
+  end
+
+  test "usage is assigned from final usage patch rather than accumulated" do
+    accumulator = LlmGateway::Adapters::NormalizedStreamAccumulator.new(provider: "test-provider", api: "test-api")
+    events = []
+
+    [
+      { type: :message_start, delta: { id: "msg_1", model: "test-model", role: "assistant" }, usage: { input: 99 } },
+      { type: :message_delta, delta: { stop_reason: "stop" }, usage: { input: 3, output: 2 } },
+      { type: :message_end }
+    ].each do |patch|
+      accumulator.push(patch) { |event| events << event }
+    end
+
+    refute_respond_to events.first.partial, :usage
+    assert_equal({ input: 3, cache_write: 0, cache_read: 0, output: 2 }, events.last.message.usage)
   end
 
   test "partial assistant message allows incomplete messages except timestamp but assistant message does not" do

--- a/test/unit/normalized_stream_accumulator_partial_test.rb
+++ b/test/unit/normalized_stream_accumulator_partial_test.rb
@@ -37,7 +37,7 @@ class NormalizedStreamAccumulatorPartialTest < Test
     assert_equal message_end.message.timestamp, message_end.message.to_h[:timestamp]
     assert_equal accumulator.result[:id], message_end.message.id
     assert_equal accumulator.result[:model], message_end.message.model
-    assert_equal({ input: 3, cache_write: 0, cache_read: 0, output: 2, total: 5 }, message_end.message.usage)
+    assert_equal({ input: 3, cache_write: 0, cache_read: 0, output: 2, total: 5, raw: {} }, message_end.message.usage)
     assert_equal accumulator.result[:usage], message_end.message.usage
     assert_equal accumulator.result[:stop_reason], message_end.message.stop_reason
     assert_equal accumulator.result[:content], message_end.message.content.map(&:to_h)
@@ -97,7 +97,7 @@ class NormalizedStreamAccumulatorPartialTest < Test
 
     assert_equal 1_716_650_000_000, events.first.partial.timestamp
     assert_equal 1_716_650_000_000, events.last.message.timestamp
-    assert_equal({ input: 0, cache_write: 0, cache_read: 0, output: 0, total: 0 }, events.last.message.usage)
+    assert_equal({ input: 0, cache_write: 0, cache_read: 0, output: 0, total: 0, raw: {} }, events.last.message.usage)
   end
 
   test "usage is assigned from final usage patch rather than accumulated" do
@@ -113,7 +113,7 @@ class NormalizedStreamAccumulatorPartialTest < Test
     end
 
     refute_respond_to events.first.partial, :usage
-    assert_equal({ input: 3, cache_write: 0, cache_read: 0, output: 2, total: 5 }, events.last.message.usage)
+    assert_equal({ input: 3, cache_write: 0, cache_read: 0, output: 2, total: 5, raw: {} }, events.last.message.usage)
   end
 
   test "usage total includes input cache and output tokens" do
@@ -122,13 +122,13 @@ class NormalizedStreamAccumulatorPartialTest < Test
 
     [
       { type: :message_start, delta: { id: "msg_1", model: "test-model", role: "assistant" } },
-      { type: :message_delta, delta: { stop_reason: "stop" }, usage: { input: 3, cache_write: 4, cache_read: 5, output: 6, total: 999 } },
+      { type: :message_delta, delta: { stop_reason: "stop" }, usage: { input: 3, cache_write: 4, cache_read: 5, output: 6, total: 999, raw: { prompt_tokens: 12 } } },
       { type: :message_end }
     ].each do |patch|
       accumulator.push(patch) { |event| events << event }
     end
 
-    expected_usage = { input: 3, cache_write: 4, cache_read: 5, output: 6, total: 18 }
+    expected_usage = { input: 3, cache_write: 4, cache_read: 5, output: 6, total: 18, raw: { prompt_tokens: 12 } }
     assert_equal expected_usage, events[1].usage
     assert_equal expected_usage, events.last.message.usage
   end


### PR DESCRIPTION
# Goal
Improve token accounting normalization so provider token outputs are exposed consistently in final responses.

# Changes made to achieve the goal
Add support for raw provider token output, include total token counts in final results, and simplify token handling by reporting final counts instead of maintaining incremental token updates.

> read the commit messages for more details
