### PR TITLE
refactor: prompt to use modern patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,28 +288,29 @@ class MathPrompt < LlmGateway::Prompt
   end
 end
 
-answer = MathPrompt.new(
+response = MathPrompt.new(
   cache_key: "math-prompt-v1",
   cache_retention: "short"
 ).run
 
-puts answer # concatenated assistant text after any tool calls complete
+puts response.role # "assistant"
+puts response.content.select { |block| block.type == "text" }.map(&:text).join
 ```
 
 How `Prompt` works now:
 
 - `prompt` is evaluated once per `run`.
-- `run(provider:, model:, reasoning:, **options)` calls `stream` and returns concatenated text content from the final `AssistantMessage`.
+- `run(provider:, model:, reasoning:, **options)` calls `stream` and returns the final normalized `AssistantMessage` after any tool calls complete.
 - `stream(input = prompt, provider:, model:, reasoning:, **options, &block)` forwards to the provider and returns the normalized `AssistantMessage`.
 - Tools are declared as tool classes in a `TOOLS` constant. `run` automatically executes returned `tool_use` blocks, appends `tool_result` messages, and loops until no tool calls remain.
 - `system_prompt`, `tools`, `model`, `reasoning`, `cache_key`, and `cache_retention` are forwarded as stream options.
 - `cache_retention` can also enable provider cache control for prompt-owned system/tool blocks where supported, and `Tool.cache true` marks a tool definition with `cache_control`.
-- `before_execute` callbacks receive the resolved input. `after_execute` callbacks receive the final `AssistantMessage` and concatenated text.
-- The old `extract_response` and `parse_response` hooks are no longer called; parse or transform the returned text after `run`.
+- `before_execute` callbacks receive the resolved input. `after_execute` callbacks receive the final `AssistantMessage`.
+- The old `extract_response` and `parse_response` hooks are no longer called; inspect, parse, or transform the returned `AssistantMessage` after `run`.
 
 ## Migration guides
 
-- [0.7.0 migration guide](docs/migration_guide_0.7.0.md) — update `Prompt` subclasses for normalized `AssistantMessage` responses, automatic tool loops, `TOOLS`, and removed response hooks.
+- [0.7.0 migration guide](docs/migration_guide_0.7.0.md) — update `Prompt` subclasses for normalized `AssistantMessage` return values, automatic tool loops, `TOOLS`, and removed response hooks.
 - [0.6.0 migration guide](docs/migration_guide_0.6.0.md) — move `model_key` to per-request `model:`, update provider keys, update `Prompt` usage, and migrate stream event/usage changes.
 - [Migrating from `chat` to `stream`](docs/migration-guide.md) — use `stream` without a block when you only need the final response.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Provide a unified translation interface for LLM Provider API's, While allowing d
   - [Provider-specific options](#provider-specific-options)
 - [Quick Start: Streaming (all events)](#quick-start-streaming-all-events)
   - [Stream API without handling events (final result only)](#stream-api-without-handling-events-final-result-only)
+- [Prompt classes](#prompt-classes)
 - [Migration guides](#migration-guides)
 - [Tools](#tools)
   - [Defining Tools](#defining-tools)
@@ -253,8 +254,62 @@ text = result.content
 puts text
 ```
 
+## Prompt classes
+
+`LlmGateway::Prompt` wraps a reusable prompt, provider/model defaults, callbacks, optional tools, and prompt-cache options around the `stream` API.
+
+```ruby
+class AddTool < LlmGateway::Tool
+  name "add"
+  description "Adds two numbers"
+  input_schema(type: "object")
+  cache true # optional: mark the tool definition as cacheable where supported
+
+  def execute(input)
+    input[:left] + input[:right]
+  end
+end
+
+class MathPrompt < LlmGateway::Prompt
+  self.provider = LlmGateway.build_provider(
+    provider: "openai_responses",
+    api_key: ENV.fetch("OPENAI_API_KEY")
+  )
+  self.model = "gpt-5.4"
+
+  TOOLS = [AddTool].freeze
+
+  def prompt
+    "What is 2 + 3? Use the add tool."
+  end
+
+  def system_prompt
+    "You are a careful math assistant."
+  end
+end
+
+answer = MathPrompt.new(
+  cache_key: "math-prompt-v1",
+  cache_retention: "short"
+).run
+
+puts answer # concatenated assistant text after any tool calls complete
+```
+
+How `Prompt` works now:
+
+- `prompt` is evaluated once per `run`.
+- `run(provider:, model:, reasoning:, **options)` calls `stream` and returns concatenated text content from the final `AssistantMessage`.
+- `stream(input = prompt, provider:, model:, reasoning:, **options, &block)` forwards to the provider and returns the normalized `AssistantMessage`.
+- Tools are declared as tool classes in a `TOOLS` constant. `run` automatically executes returned `tool_use` blocks, appends `tool_result` messages, and loops until no tool calls remain.
+- `system_prompt`, `tools`, `model`, `reasoning`, `cache_key`, and `cache_retention` are forwarded as stream options.
+- `cache_retention` can also enable provider cache control for prompt-owned system/tool blocks where supported, and `Tool.cache true` marks a tool definition with `cache_control`.
+- `before_execute` callbacks receive the resolved input. `after_execute` callbacks receive the final `AssistantMessage` and concatenated text.
+- The old `extract_response` and `parse_response` hooks are no longer called; parse or transform the returned text after `run`.
+
 ## Migration guides
 
+- [0.7.0 migration guide](docs/migration_guide_0.7.0.md) — update `Prompt` subclasses for normalized `AssistantMessage` responses, automatic tool loops, `TOOLS`, and removed response hooks.
 - [0.6.0 migration guide](docs/migration_guide_0.6.0.md) — move `model_key` to per-request `model:`, update provider keys, update `Prompt` usage, and migrate stream event/usage changes.
 - [Migrating from `chat` to `stream`](docs/migration-guide.md) — use `stream` without a block when you only need the final response.
 

--- a/docs/migration_guide_0.7.0.md
+++ b/docs/migration_guide_0.7.0.md
@@ -1,0 +1,133 @@
+# Migration guide: 0.7.0
+
+This release refactors `LlmGateway::Prompt` around the normalized streaming response model and adds first-class prompt-owned tool loops.
+
+## Breaking changes
+
+### `Prompt#run` uses `stream` and normalized `AssistantMessage`
+
+`run` now calls the configured provider's `stream` method and expects it to return a normalized `LlmGateway::AssistantMessage` with `content` blocks.
+
+If you use test doubles or custom providers with `Prompt`, update them from hash-like chat responses:
+
+```ruby
+# Before
+{ choices: [ { content: "hello" } ] }
+```
+
+To `AssistantMessage` responses:
+
+```ruby
+LlmGateway::AssistantMessage.new(
+  id: "msg_123",
+  model: "gpt-5.4",
+  role: "assistant",
+  stop_reason: "stop",
+  provider: "openai",
+  api: "responses",
+  timestamp: Time.now.to_i,
+  usage: {},
+  content: [ { type: "text", text: "hello" } ]
+)
+```
+
+`run` returns the concatenated text from text content blocks after tool handling is complete.
+
+### `extract_response` and `parse_response` hooks were removed
+
+`Prompt#run` no longer calls custom `extract_response` or `parse_response` methods.
+
+Move response transformation outside the prompt call, or wrap `run` in your subclass:
+
+```ruby
+class JsonPrompt < LlmGateway::Prompt
+  def prompt
+    "Return JSON."
+  end
+
+  def run_json(**options)
+    JSON.parse(run(**options))
+  end
+end
+```
+
+### Tools are declared with `TOOLS`
+
+Prompt tools are now class-level tool classes declared in a `TOOLS` constant. `Prompt#tools` returns their provider definitions.
+
+```ruby
+class AddTool < LlmGateway::Tool
+  name "add"
+  description "Adds two numbers"
+  input_schema(type: "object")
+  cache true # optional cache_control marker where supported
+
+  def execute(input)
+    input[:left] + input[:right]
+  end
+end
+
+class MathPrompt < LlmGateway::Prompt
+  TOOLS = [AddTool].freeze
+
+  def prompt
+    "What is 2 + 3? Use the add tool."
+  end
+end
+```
+
+If a prompt has no tools, `tools` now returns `[]` instead of `nil`.
+
+### `run` automatically loops over tool calls
+
+When the assistant returns `tool_use` content blocks, `Prompt#run` now:
+
+1. Finds the matching class in `TOOLS` by tool name.
+2. Executes `tool_class.new.execute(input)`.
+3. Appends the assistant message and a user `tool_result` message.
+4. Calls `stream` again.
+5. Repeats until the response has no `tool_use` blocks.
+
+Unknown tools and tool execution errors are returned to the model as `tool_result` content rather than raised.
+
+### Prompt input is resolved once per run
+
+`prompt` is evaluated once at the start of `run`. The same initial input is used when building follow-up messages for tool results, so dynamic or expensive prompt builders are not re-evaluated during a single run.
+
+### `Prompt#stream` accepts explicit input
+
+`stream` now has this signature:
+
+```ruby
+stream(input = prompt, provider: nil, model: nil, reasoning: nil, **options, &block)
+```
+
+You can still call `stream` with no input, but subclasses or callers can now provide a transcript directly:
+
+```ruby
+prompt.stream([{ role: "user", content: "Hello" }], model: "gpt-5.4")
+```
+
+### Prompt-level cache options
+
+Prompt instances accept and forward cache options:
+
+```ruby
+SummaryPrompt.new(
+  provider: provider,
+  model: "gpt-5.4",
+  cache_key: "summary-v1",
+  cache_retention: "short"
+).run
+```
+
+These are passed to providers as managed `cache_key` / `cache_retention` stream options. For providers that support cache control on system/tool blocks, `cache_retention` may also apply cache metadata to the prompt-owned `system_prompt` and tool definitions. Tool classes can also opt into cache metadata with `cache true`.
+
+## Migration checklist
+
+- [ ] Update custom provider/test doubles used by `Prompt` to return `AssistantMessage`.
+- [ ] Remove `extract_response` and `parse_response` hooks; parse or transform after `run`.
+- [ ] Move prompt tool definitions to a `TOOLS = [ToolClass]` constant.
+- [ ] Account for automatic tool-loop execution in `run`.
+- [ ] Update any `tools.nil?` checks; no-tool prompts now expose `[]`.
+- [ ] Use `cache_key:` / `cache_retention:` on prompt instances when prompt caching is needed.

--- a/docs/migration_guide_0.7.0.md
+++ b/docs/migration_guide_0.7.0.md
@@ -31,7 +31,9 @@ LlmGateway::AssistantMessage.new(
 )
 ```
 
-`run` returns the concatenated text from text content blocks after tool handling is complete.
+`run` returns the final normalized `AssistantMessage` after tool handling is complete. It no longer extracts or concatenates text content for you; inspect `response.content` when you need text or other blocks.
+
+`after_execute` callbacks now receive only the final `AssistantMessage` instead of both the message and extracted text.
 
 ### `extract_response` and `parse_response` hooks were removed
 
@@ -46,7 +48,9 @@ class JsonPrompt < LlmGateway::Prompt
   end
 
   def run_json(**options)
-    JSON.parse(run(**options))
+    response = run(**options)
+    text = response.content.select { |block| block.type == "text" }.map(&:text).join
+    JSON.parse(text)
   end
 end
 ```
@@ -126,7 +130,8 @@ These are passed to providers as managed `cache_key` / `cache_retention` stream 
 ## Migration checklist
 
 - [ ] Update custom provider/test doubles used by `Prompt` to return `AssistantMessage`.
-- [ ] Remove `extract_response` and `parse_response` hooks; parse or transform after `run`.
+- [ ] Remove `extract_response` and `parse_response` hooks; inspect, parse, or transform the returned `AssistantMessage` after `run`.
+- [ ] Update `after_execute` callbacks to accept the final `AssistantMessage` only.
 - [ ] Move prompt tool definitions to a `TOOLS = [ToolClass]` constant.
 - [ ] Account for automatic tool-loop execution in `run`.
 - [ ] Update any `tools.nil?` checks; no-tool prompts now expose `[]`.

--- a/lib/llm_gateway/prompt.rb
+++ b/lib/llm_gateway/prompt.rb
@@ -33,11 +33,9 @@ module LlmGateway
 
       response = run_tool_loop(input, provider: resolved_provider(provider), model: model, reasoning: reasoning, **options, &block)
 
-      response_content = response.content.select { |content| content.respond_to?(:text) }.map(&:text).join
+      run_callbacks(:after_execute, response)
 
-      run_callbacks(:after_execute, response, response_content)
-
-      response_content
+      response
     end
 
     def stream(input = prompt, provider: nil, model: nil, reasoning: nil, **options, &block)
@@ -115,9 +113,6 @@ module LlmGateway
         content: requests.map { |request| find_and_execute_tool(request).to_h }
       }
       messages
-    end
-
-    def extract_response_content(response)
     end
 
     def default_stream_options(model: nil, reasoning: nil)

--- a/lib/llm_gateway/prompt.rb
+++ b/lib/llm_gateway/prompt.rb
@@ -4,6 +4,7 @@ module LlmGateway
   class Prompt
     class_attribute :provider, :model, :reasoning
     class_attribute :before_execute_callbacks, :after_execute_callbacks, instance_accessor: false, default: []
+    attr_accessor :cache_key, :cache_retention
 
     def self.before_execute(*methods, &block)
       self.before_execute_callbacks += methods
@@ -15,50 +16,47 @@ module LlmGateway
       self.after_execute_callbacks += [ block ] if block_given?
     end
 
-    def initialize(provider: nil, model: nil, reasoning: nil)
+    def initialize(provider: nil, model: nil, reasoning: nil, cache_key: nil, cache_retention: nil)
       @provider = provider || self.class.provider
       @model = model || self.class.model
       @reasoning = reasoning || self.class.reasoning
+      @cache_key = cache_key
+      @cache_retention = cache_retention
     end
 
-    def run
-      run_callbacks(:before_execute, prompt)
+    def run(provider: nil, model: nil, reasoning: nil, **options, &block)
+      # Resolve the prompt once so dynamic or expensive prompt builders are not
+      # evaluated multiple times during a single run.
+      input = prompt
 
-      response = stream
+      run_callbacks(:before_execute, input)
 
-      response_content = if respond_to?(:extract_response)
-        extract_response(response)
-      else
-        response[:choices][0][:content]
-      end
+      response = run_tool_loop(input, provider: resolved_provider(provider), model: model, reasoning: reasoning, **options, &block)
 
-      result = if respond_to?(:parse_response)
-        parse_response(response_content)
-      else
-        response_content
-      end
+      response_content = response.content.select { |content| content.respond_to?(:text) }.map(&:text).join
 
       run_callbacks(:after_execute, response, response_content)
 
-      result
+      response_content
     end
 
-    def stream(provider: nil, model: nil, reasoning: nil, **options)
-      stream_provider = provider || self.provider
-      stream_model = model || self.model
-      stream_reasoning = reasoning || self.reasoning
-      options[:model] = stream_model if stream_model
-      options[:reasoning] = stream_reasoning if stream_reasoning
+    def stream(input = prompt, provider: nil, model: nil, reasoning: nil, **options, &block)
+      stream_provider = resolved_provider(provider)
+      stream_options = default_stream_options(model: model, reasoning: reasoning).merge(options)
 
-      stream_provider.stream(prompt, tools: tools, system: system_prompt, **options)
+      stream_provider.stream(input, **stream_options, &block)
+    end
+
+    def self.tools
+      const_defined?(:TOOLS, false) ? self::TOOLS : []
+    end
+
+    def self.find_tool(name)
+      tools.find { |tool| tool.tool_name == name }
     end
 
     def tools
-      nil
-    end
-
-    def self.find_tool(tool_name)
-      tools.find { |tool| tool.tool_name == tool_name }
+      self.class.tools.map(&:definition)
     end
 
     def system_prompt
@@ -67,13 +65,91 @@ module LlmGateway
 
     private
 
+    def find_and_execute_tool(tool_request)
+      tool_name = tool_request.name
+      tool_input = tool_request.input
+      tool_class = self.class.find_tool(tool_name)
+
+      result = begin
+        if tool_class
+          execute_tool(tool_class, tool_input)
+        else
+          "Unknown tool: #{tool_name}"
+        end
+      rescue StandardError => e
+        "Error executing tool: #{e.message}"
+      end
+      ToolResult.new(
+        type: "tool_result",
+        tool_use_id: tool_request.id,
+        content: result,
+      )
+    end
+
+    def execute_tool(tool_class, tool_input)
+      tool_class.new.execute(tool_input)
+    end
+
+    def run_tool_loop(input, provider: nil, model: nil, reasoning: nil, **options, &block)
+      response = stream(input, provider: provider, model: model, reasoning: reasoning, **options, &block)
+
+      while tool_requests(response).any?
+        input = prompt_with_tool_results(input, response, tool_requests(response))
+        response = stream(input, provider: provider, model: model, reasoning: reasoning, **options, &block)
+      end
+
+      response
+    end
+
+    def tool_requests(response)
+      return [] unless response.respond_to?(:content)
+
+      response.content.select { |content| content.respond_to?(:type) && content.type == "tool_use" }
+    end
+
+    def prompt_with_tool_results(input, response, requests)
+      messages = input.is_a?(Array) ? input.dup : [ { role: "user", content: input } ]
+      messages << response.to_h
+      messages << {
+        role: "user",
+        content: requests.map { |request| find_and_execute_tool(request).to_h }
+      }
+      messages
+    end
+
+    def extract_response_content(response)
+    end
+
+    def default_stream_options(model: nil, reasoning: nil)
+      {
+        tools: tools,
+        system: system_prompt,
+        model: resolved_model(model),
+        reasoning: resolved_reasoning(reasoning),
+        cache_key: cache_key,
+        cache_retention: cache_retention
+      }.compact
+    end
+
+    def resolved_provider(provider)
+      provider || self.provider
+    end
+
+    def resolved_model(model)
+      model || self.model
+    end
+
+    def resolved_reasoning(reasoning)
+      reasoning || self.reasoning
+    end
+
     def run_callbacks(callback_type, *args)
-      callbacks = self.class.send("#{callback_type}_callbacks")
-      callbacks.each do |callback|
-        if callback.is_a?(Proc)
+      self.class.public_send("#{callback_type}_callbacks").each do |callback|
+        case callback
+        when Proc
           instance_exec(*args, &callback)
-        elsif callback.is_a?(Symbol) || callback.is_a?(String)
-          send(callback, *args)
+        when Symbol, String
+          public_send(callback, *args)
         end
       end
     end

--- a/lib/llm_gateway/utils.rb
+++ b/lib/llm_gateway/utils.rb
@@ -51,7 +51,7 @@ module LlmGateway
 end
 
 class Class
-  def class_attribute(*names, instance_accessor: true, default: nil)
+  def class_attribute(*names, instance_accessor: true, instance_reader: instance_accessor, instance_writer: instance_accessor, instance_predicate: true, default: nil)
     names.each do |name|
       ivar = :"@#{name}"
       instance_variable_set(ivar, default)
@@ -75,7 +75,7 @@ class Class
         instance_variable_set(ivar, value)
       end
 
-      if instance_accessor
+      if instance_reader
         define_method(name) do
           if instance_variable_defined?(ivar)
             instance_variable_get(ivar)
@@ -83,8 +83,12 @@ class Class
             self.class.public_send(name)
           end
         end
+      end
 
-        define_method("#{name}=") { |value| instance_variable_set(ivar, value) }
+      define_method("#{name}=") { |value| instance_variable_set(ivar, value) } if instance_writer
+
+      if instance_predicate
+        define_method("#{name}?") { !!public_send(name) }
       end
     end
   end

--- a/test/unit/prompt_test.rb
+++ b/test/unit/prompt_test.rb
@@ -12,13 +12,51 @@ class PromptTest < Test
 
     def stream(message, **options)
       @calls << { message: message, options: options }
-      { choices: [ { content: "ok" } ] }
+      AssistantMessage.new(
+        id: "msg_recording",
+        model: options[:model] || "test-model",
+        usage: {},
+        role: "assistant",
+        stop_reason: "stop",
+        provider: "test",
+        api: "test",
+        timestamp: Time.now.to_i,
+        content: [ { type: "text", text: "ok" } ]
+      )
     end
   end
 
   class ConfigurablePrompt < LlmGateway::Prompt
     def prompt
       "hello"
+    end
+  end
+
+  class AddTool < LlmGateway::Tool
+    name "add"
+    description "Adds two numbers"
+    input_schema({ type: "object" })
+
+    def execute(input)
+      input[:left] + input[:right]
+    end
+  end
+
+  class ToolPrompt < ConfigurablePrompt
+    TOOLS = [ AddTool ].freeze
+  end
+
+  class SequentialProvider
+    attr_reader :calls
+
+    def initialize(*responses)
+      @responses = responses
+      @calls = []
+    end
+
+    def stream(message, **options)
+      @calls << { message: message, options: options }
+      @responses.shift
     end
   end
 
@@ -34,7 +72,7 @@ class PromptTest < Test
     ConfigurablePrompt.model = "class-model"
 
     prompt = ConfigurablePrompt.new
-    prompt.stream
+    prompt.run
 
     assert_equal provider, prompt.provider
     assert_equal "class-model", prompt.model
@@ -48,17 +86,17 @@ class PromptTest < Test
     ConfigurablePrompt.provider = class_provider
     ConfigurablePrompt.model = "class-model"
 
-    ConfigurablePrompt.new(provider: instance_provider, model: "instance-model").stream
+    ConfigurablePrompt.new(provider: instance_provider, model: "instance-model").run
 
     assert_empty class_provider.calls
     assert_equal "instance-model", instance_provider.calls.last[:options][:model]
   end
 
-  test "stream provider and model override instance configuration" do
+  test "run provider and model override instance configuration" do
     instance_provider = RecordingProvider.new
     stream_provider = RecordingProvider.new
 
-    ConfigurablePrompt.new(provider: instance_provider, model: "instance-model").stream(
+    ConfigurablePrompt.new(provider: instance_provider, model: "instance-model").run(
       provider: stream_provider,
       model: "stream-model"
     )
@@ -74,19 +112,55 @@ class PromptTest < Test
       provider: provider,
       model: "keyword-model",
       reasoning: "low"
-    ).stream
+    ).run
 
     assert_equal "keyword-model", provider.calls.last[:options][:model]
     assert_equal "low", provider.calls.last[:options][:reasoning]
   end
 
-  test "uses class reasoning and allows stream override" do
+  test "uses class reasoning and allows run override" do
     provider = RecordingProvider.new
     ConfigurablePrompt.provider = provider
     ConfigurablePrompt.reasoning = "high"
 
-    ConfigurablePrompt.new.stream(reasoning: "medium")
+    ConfigurablePrompt.new.run(reasoning: "medium")
 
     assert_equal "medium", provider.calls.last[:options][:reasoning]
+  end
+
+  test "run executes tool calls and continues with tool results" do
+    provider = SequentialProvider.new(
+      assistant_message(content: [ { type: "tool_use", id: "toolu_add", name: "add", input: { left: 2, right: 3 } } ], stop_reason: "tool_use"),
+      assistant_message(content: [ { type: "text", text: "5" } ])
+    )
+
+    result = ToolPrompt.new(provider: provider, model: "test-model").run
+
+    assert_equal "5", result
+    assert_equal 2, provider.calls.length
+    assert_equal [ AddTool.definition ], provider.calls.first[:options][:tools]
+    assert_equal "hello", provider.calls.first[:message]
+    continued_message = provider.calls[1][:message]
+    assert_equal "user", continued_message[0][:role]
+    assert_equal "hello", continued_message[0][:content]
+    assert_equal "assistant", continued_message[1][:role]
+    assert_equal [ { type: "tool_result", tool_use_id: "toolu_add", content: 5 } ], continued_message[2][:content]
+    assert_equal "test-model", provider.calls[1][:options][:model]
+  end
+
+  private
+
+  def assistant_message(content:, stop_reason: "stop")
+    AssistantMessage.new(
+      id: "msg_#{object_id}_#{rand(1000)}",
+      model: "test-model",
+      usage: {},
+      role: "assistant",
+      stop_reason: stop_reason,
+      provider: "test",
+      api: "test",
+      timestamp: Time.now.to_i,
+      content: content
+    )
   end
 end

--- a/test/unit/prompt_test.rb
+++ b/test/unit/prompt_test.rb
@@ -136,7 +136,7 @@ class PromptTest < Test
 
     result = ToolPrompt.new(provider: provider, model: "test-model").run
 
-    assert_equal "5", result
+    assert_equal [ "5" ], result.content.map(&:text)
     assert_equal 2, provider.calls.length
     assert_equal [ AddTool.definition ], provider.calls.first[:options][:tools]
     assert_equal "hello", provider.calls.first[:message]


### PR DESCRIPTION
# Goal
Modernize the prompt helper so it works better with future harness classes while staying focused on running a prompt with tools and returning the model response.

# Changes made to achieve the goal
Refactors prompt behavior around tool-loop handling, configurable caching for tools and system prompts, and returning the full assistant message. Removes older response extraction/parsing hooks so specialized parsing can live outside the prompt helper.

> read the commit messages for more details