### PR TITLE
feat: add agent harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Provide a unified translation interface for LLM Provider API's, While allowing d
   - [Defining Tools](#defining-tools)
   - [Handling Tool Calls](#handling-tool-calls)
   - [Server Tool Use](#server-tool-use)
+- [Agents](#agents)
+  - [Agent events](#agent-events)
+  - [Session managers and persistence](#session-managers-and-persistence)
+  - [Queues, steering, and follow-ups](#queues-steering-and-follow-ups)
+  - [Compaction](#compaction)
+  - [Built-in agent tools](#built-in-agent-tools)
 - [Image Input](#image-input)
 - [Thinking / Reasoning](#thinking--reasoning)
   - [Streaming Thinking Content](#streaming-thinking-content)
@@ -459,6 +465,152 @@ Cross-provider server tool handoffs are best-effort:
 - Cross-provider replay converts server tool uses into normal `tool_use` blocks and server tool results into `tool_result` blocks.
 - `llm_gateway` does not translate server tool names between providers. Supply the target provider's server tool definition on the follow-up request.
 - Some providers require the same server tool to be selected in `tools:` when replaying prior server tool activity.
+
+## Agents
+
+`LlmGateway::Agents::Harness` wraps the streaming API in a stateful conversation loop. It stores session history, executes `LlmGateway::Tool` classes automatically when the model emits tool calls, appends `tool_result` messages, repeats model turns until there are no more tool calls, supports queued user messages while a turn is running, and compacts older session context when needed.
+
+```ruby
+require "llm_gateway"
+require "json"
+
+class WeatherTool < LlmGateway::Tool
+  name "get_weather"
+  description "Get current weather for a location"
+  input_schema(
+    type: "object",
+    properties: {
+      location: { type: "string" }
+    },
+    required: ["location"]
+  )
+
+  def execute(input)
+    location = input[:location] || input["location"]
+
+    JSON.generate(
+      location: location,
+      temperature: 14,
+      condition: "Cloudy"
+    )
+  end
+end
+
+class WeatherHarness < LlmGateway::Agents::Harness
+  TOOLS = [WeatherTool]
+
+  def system_prompt
+    "You are a concise weather assistant. Use tools when useful."
+  end
+end
+
+adapter = LlmGateway.build_provider(
+  provider: "openai_responses",
+  api_key: ENV.fetch("OPENAI_API_KEY")
+)
+
+session = LlmGateway::Agents::InMemorySessionManager.new("weather-session")
+harness = WeatherHarness.new(
+  session,
+  provider: adapter,
+  model: "gpt-5.4",
+  reasoning: "high"
+)
+
+harness.prompt_message(
+  role: "user",
+  content: [ { type: "text", text: "What is the weather in London?" } ]
+) do |event|
+  case event.type
+  when :agent_start
+    puts "Agent started"
+  when :turn_start
+    puts "Turn started"
+  when :message_update
+    # Streaming provider events are wrapped on message update events.
+    stream_event = event.stream_event
+    print stream_event.delta if stream_event.respond_to?(:delta)
+  when :tool_execution_start
+    puts "\nExecuting #{event.parameters[:name]}"
+  when :tool_execution_end
+    puts "\nTool result: #{event.result.content}"
+  when :agent_end
+    puts "\nAgent finished"
+  end
+end
+
+puts harness.transcript.inspect
+```
+
+Harness behavior:
+
+- `prompt_message(message)` accepts an LLM-shaped message hash, records it in the session, streams the provider response, records the final assistant message, executes any returned tool calls from the harness class's `TOOLS` constant, records a user `tool_result` message, and continues until no tool calls remain.
+- Harnesses pass `tools`, `system_prompt`, `model`, `reasoning`, `cache_key`, and `cache_retention` through the inherited `Prompt#stream` defaults.
+- Pass `model:` and optional `reasoning:` to `new`, or set them later with `harness.model = "..."` / `harness.reasoning = "..."`. Model and reasoning changes are recorded as session events.
+- `harness.transcript` (also aliased as `prompt`) returns the current model input: the latest compaction summary, if any, followed by active messages.
+- `harness.run` / `harness.continue` continues from the current session state without adding a new user message.
+
+### Agent events
+
+When a block is passed to `prompt_message`, `run`, or `continue`, the harness emits typed events:
+
+- `:agent_start`
+- `:turn_start`
+- `:message_start`
+- `:message_update` with `event.stream_event` containing the normalized streaming event from the provider
+- `:message_end` with `event.message`
+- `:tool_execution_start` with `event.parameters` (`id`, `type`, `name`, `input`)
+- `:tool_execution_end` with `event.parameters` and `event.result`
+- `:turn_end` with `event.message` and `event.tool_results`
+- `:agent_end`
+
+### Session managers and persistence
+
+- `LlmGateway::Agents::InMemorySessionManager.new(session_id = nil)` keeps session events in memory for the lifetime of the process.
+- `LlmGateway::Agents::FileSessionManager.new(file_name = nil, session_id: nil, session_start: nil, session_dir: nil)` persists session events as JSONL. If `file_name` is omitted, files are created under `LLM_GATEWAY_SESSION_DIR` or `~/.llm_gateway/sessions`.
+- File sessions load existing JSONL sessions and append new events to the same file.
+- Session event types include `session`, `message`, `model_change`, `reasoning_change`, and `compaction`. Queued messages are kept in memory and are persisted only when drained into the active conversation.
+
+### Queues, steering, and follow-ups
+
+Calls made while a harness is already processing are queued instead of recursively starting another run.
+
+- `prompt_message(message)` queues to the harness's default queue while busy. The default is `:next_turn`.
+- `steer_message(message)`, `follow_up_message(message)`, and `next_turn_message(message)` enqueue to their matching queue while busy. When idle, they behave like `prompt_message`.
+- `:steer` messages are drained before the next model request in the current run.
+- `:follow_up` messages run after the current turn finishes and before `:next_turn` messages.
+- `:next_turn` messages run after the current agent run completes.
+- Queued messages drain as `:all` by default. Set `harness.queue_drain_mode = :one_at_a_time` to drain one FIFO message at a time.
+- Set `harness.default_queue_mode = :steer`, `:follow_up`, or `:next_turn` to change where busy `prompt_message` calls are queued.
+
+### Compaction
+
+Before starting a new user message and before draining queued follow-up/next-turn work, the harness checks whether compaction is needed. It compacts when either:
+
+- the latest recorded message usage exceeds `LlmGateway::Agents::Harness::COMPACTION_TOKEN_THRESHOLD`, or
+- the latest assistant message is older than `LlmGateway::Agents::Harness::COMPACTION_IDLE_THRESHOLD_SECONDS`.
+
+Compaction calls `adapter.stream(active_messages, system: "Summarize the conversation so far for future context.", tools: [])`, stores the returned assistant message as a `compaction` event, and builds future model input as the compaction summary plus messages recorded after that compaction.
+
+### Built-in agent tools
+
+The agent harness can use any `LlmGateway::Tool` subclass in its `TOOLS` constant. The library also provides optional coding-oriented tools. Require the ones you want and include them in your harness:
+
+```ruby
+require "llm_gateway/agents/tools/read_tool"
+require "llm_gateway/agents/tools/bash_tool"
+require "llm_gateway/agents/tools/edit_tool"
+require "llm_gateway/agents/tools/write_tool"
+
+class CodingHarness < LlmGateway::Agents::Harness
+  TOOLS = [ReadTool, BashTool, EditTool, WriteTool]
+end
+```
+
+- `ReadTool` (`read`) reads text files and supported images (`jpg`, `png`, `gif`, `webp`). Text output is truncated to 2,000 lines or 50KB from the start; use `offset`/`limit` to continue through large files.
+- `BashTool` (`bash`) runs a command in the current working directory, combines stdout/stderr, supports an optional timeout, truncates long output to the last 2,000 lines or 50KB, and saves full truncated output to a temp file.
+- `EditTool` (`edit`) edits one file with one or more exact `edits[].oldText` → `edits[].newText` replacements. Each `oldText` must be unique in the original file and edits must not overlap.
+- `WriteTool` (`write`) creates parent directories as needed and writes or overwrites a file.
 
 ## Image Input
 

--- a/lib/llm_gateway.rb
+++ b/lib/llm_gateway.rb
@@ -7,6 +7,10 @@ require_relative "llm_gateway/base_client"
 require_relative "llm_gateway/client"
 require_relative "llm_gateway/prompt"
 require_relative "llm_gateway/tool"
+require_relative "llm_gateway/agents/event"
+require_relative "llm_gateway/agents/in_memory_session_manager"
+require_relative "llm_gateway/agents/file_session_manager"
+require_relative "llm_gateway/agents/harness"
 
 # Load clients - order matters for inheritance
 require_relative "llm_gateway/clients/anthropic"

--- a/lib/llm_gateway/agents/event.rb
+++ b/lib/llm_gateway/agents/event.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require_relative "../adapters/structs"
+
+module LlmGateway
+  module Agents
+    module Event
+      AgentEventType = Types::Coercible::Symbol.enum(
+        :agent_start,
+        :turn_start,
+        :message_start,
+        :message_update,
+        :message_end,
+        :tool_execution_start,
+        :tool_execution_end,
+        :turn_end,
+        :agent_end
+      )
+
+      StreamEvent =
+        Types.Instance(AssistantStreamEvent) |
+        Types.Instance(AssistantStreamMessageEvent) |
+        Types.Instance(AssistantStreamMessageEndEvent)
+
+      ToolParameters = Types::Hash.schema(
+        id: Types::String,
+        type: Types::String.enum("tool_use"),
+        name: Types::String,
+        input: Types::Hash
+      )
+
+      class ToolCallResult < ::BaseStruct
+        attribute :type, Types::Coercible::Symbol.enum(:tool_result)
+        attribute :tool_use_id, Types::String
+        attribute :content, Types::Any
+
+        def to_h
+          {
+            type: type.to_s,
+            tool_use_id: tool_use_id,
+            content: content
+          }
+        end
+
+        def dig(*keys)
+          to_h.dig(*keys)
+        end
+      end
+
+      class Base < ::BaseStruct
+        attribute :type, AgentEventType
+
+        def to_h
+          {
+            type: type
+          }
+        end
+      end
+
+      class AgentStart < Base
+        attribute :type, Types::Coercible::Symbol.default(:agent_start).enum(:agent_start)
+      end
+
+      class TurnStart < Base
+        attribute :type, Types::Coercible::Symbol.default(:turn_start).enum(:turn_start)
+      end
+
+      class MessageStart < Base
+        attribute :type, Types::Coercible::Symbol.default(:message_start).enum(:message_start)
+      end
+
+      class MessageUpdate < Base
+        attribute :type, Types::Coercible::Symbol.default(:message_update).enum(:message_update)
+        attribute :stream_event, StreamEvent
+      end
+
+      class MessageEnd < Base
+        attribute :type, Types::Coercible::Symbol.default(:message_end).enum(:message_end)
+        attribute :message, Types.Instance(AssistantMessage)
+      end
+
+      class ToolExecutionStart < Base
+        attribute :type, Types::Coercible::Symbol.default(:tool_execution_start).enum(:tool_execution_start)
+        attribute :parameters, ToolParameters
+      end
+
+      class ToolExecutionEnd < Base
+        attribute :type, Types::Coercible::Symbol.default(:tool_execution_end).enum(:tool_execution_end)
+        attribute :parameters, ToolParameters
+        attribute :result, ToolCallResult
+      end
+
+      class TurnEnd < Base
+        attribute :type, Types::Coercible::Symbol.default(:turn_end).enum(:turn_end)
+        attribute :message, Types.Instance(AssistantMessage)
+        attribute :tool_results, Types::Array.of(Types.Instance(::ToolResult))
+      end
+
+      class AgentEnd < Base
+        attribute :type, Types::Coercible::Symbol.default(:agent_end).enum(:agent_end)
+        attribute :messages, Types::Array.of(Types::Hash)
+      end
+    end
+  end
+end

--- a/lib/llm_gateway/agents/file_session_manager.rb
+++ b/lib/llm_gateway/agents/file_session_manager.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "json"
+require "securerandom"
+require "time"
+require_relative "in_memory_session_manager"
+
+module LlmGateway
+  module Agents
+    class FileSessionManager < InMemorySessionManager
+      attr_reader :file_name, :session_path
+
+      def initialize(file_name = nil, session_id: nil, session_start: nil, session_dir: nil)
+        super(session_id)
+        @file_name = file_name
+        @preset_session_start = session_start
+        @session_dir = session_dir
+      end
+
+      def session_id
+        events
+        @session_id
+      end
+
+      def session_start
+        events
+        @session_start
+      end
+
+      def normalize_path(file_name)
+        File.expand_path(file_name)
+      end
+
+      def events
+        @events ||= begin
+          @session_path = normalize_path(file_name) if file_name
+          if @session_path && File.exist?(@session_path)
+            load_session(@session_path)
+          else
+            create_new_session
+          end
+        end
+      end
+
+      private
+
+      def create_new_session
+        @session_id ||= SecureRandom.uuid
+        @session_start = @preset_session_start || Time.now.strftime("%Y%m%d_%H%M%S")
+
+        session_event = {
+          type: "session",
+          id: @session_id,
+          timestamp: @session_start
+        }
+
+        @session_path ||= File.join(session_dir, "#{@session_start}_#{@session_id}.jsonl")
+        FileUtils.mkdir_p(File.dirname(@session_path))
+        File.open(@session_path, "a") do |file|
+          file.puts(JSON.generate(session_event))
+        end
+
+        [ session_event ]
+      end
+
+      def load_session(path)
+        loaded_events = []
+        File.foreach(path).with_index(1) do |line, line_number|
+          next if line.strip.empty?
+
+          loaded_events << JSON.parse(line, symbolize_names: true)
+        rescue JSON::ParserError => e
+          raise ArgumentError, "Invalid JSONL in #{path} at line #{line_number}: #{e.message}"
+        end
+
+        session_event = loaded_events.find { |event| event[:type] == "session" }
+        @session_id = session_event[:id] if session_event&.dig(:id)
+        @session_start = session_event[:timestamp] if session_event&.dig(:timestamp)
+
+        loaded_events
+      end
+
+      def persist_entry(entry)
+        attributes = super
+
+        FileUtils.mkdir_p(File.dirname(session_path))
+        File.open(session_path, "a") do |file|
+          file.puts(JSON.generate(entry))
+        end
+
+        attributes
+      end
+
+      def session_dir
+        File.expand_path(@session_dir || ENV.fetch("LLM_GATEWAY_SESSION_DIR", "~/.llm_gateway/sessions"))
+      end
+    end
+  end
+end

--- a/lib/llm_gateway/agents/harness.rb
+++ b/lib/llm_gateway/agents/harness.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require_relative "event"
+require_relative "../utils"
+
+module LlmGateway
+  module Agents
+    class Harness < LlmGateway::Prompt
+      COMPACTION_TOKEN_THRESHOLD = 180_000
+      COMPACTION_IDLE_THRESHOLD_SECONDS = 60 * 60
+      attr_accessor :provider
+      attr_reader :session_manager, :default_queue_mode, :queue_drain_mode,
+                  :model, :reasoning
+
+      def initialize(session_manager, provider:, model: nil, reasoning: "high")
+        @provider = provider
+        super(provider: provider, model: model, reasoning: reasoning)
+        @session_manager = session_manager
+        sync_initial_configuration_events
+        self.default_queue_mode = :next_turn
+        self.queue_drain_mode = :all
+      end
+
+      def transcript
+        session_manager.build_model_input_messages
+      end
+      alias :prompt :transcript
+
+      def prompt_message(message, &block)
+        enqueue_or_run_message(message, default_queue_mode, &block)
+      end
+
+      def steer_message(message, &block)
+        enqueue_or_run_message(message, :steer, &block)
+      end
+
+      def follow_up_message(message, &block)
+        enqueue_or_run_message(message, :follow_up, &block)
+      end
+
+      def next_turn_message(message, &block)
+        enqueue_or_run_message(message, :next_turn, &block)
+      end
+
+      def default_queue_mode=(mode)
+        @default_queue_mode = session_manager.validate_queue!(mode)
+      end
+
+      def queue_drain_mode=(mode)
+        @queue_drain_mode = session_manager.validate_drain_mode!(mode)
+      end
+
+      def model=(model_id)
+        return @model if @model == model_id
+
+        @model = model_id
+        publish_session_event(type: "model_change", model_id: model_id)
+        @model
+      end
+
+      def reasoning=(level)
+        return @reasoning if @reasoning == level
+
+        @reasoning = level
+        publish_session_event(type: "reasoning_change", reasoning: level)
+        @reasoning
+      end
+
+      def compact
+        session_manager.compaction(provider)
+      end
+
+      def run(&block)
+        emit(Event::AgentStart.new, &block)
+        drain_queue(:steer)
+        emit(Event::TurnStart.new, &block)
+        emit(Event::MessageStart.new, &block)
+
+        assistant_message = stream do |event|
+          emit(Event::MessageUpdate.new(stream_event: event), &block)
+        end
+
+        session_manager.push_message(assistant_message.to_h)
+        emit(Event::MessageEnd.new(message: assistant_message), &block)
+
+        tool_results = tool_requests(assistant_message).map do |message|
+          parameters = message.to_h
+          emit(Event::ToolExecutionStart.new(parameters: parameters), &block)
+          tool_result = find_and_execute_tool(message)
+          emit(Event::ToolExecutionEnd.new(parameters: parameters, result: tool_result), &block)
+          tool_result
+        end
+
+        tool_result_content = tool_results.map(&:to_h)
+        session_manager.push_message(
+          role: "user",
+          content: tool_result_content,
+        ) unless tool_result_content.empty?
+
+        turn_end_event = Event::TurnEnd.new(message: assistant_message, tool_results: tool_results)
+        emit(turn_end_event, &block)
+
+        if tool_results.length.positive?
+          return run(&block)
+        end
+
+        if session_manager.queued_messages?(:follow_up)
+          compact_if_needed
+          return run(&block) if drain_queue(:follow_up).any?
+        end
+
+        emit(Event::AgentEnd.new(messages: []), &block)
+        assistant_message
+      end
+      alias :continue   :run
+
+      private
+
+      def publish_session_event(type:, **attributes)
+        session_manager.push_entry(type: type, **attributes)
+      end
+
+      def sync_initial_configuration_events
+        publish_session_event(type: "model_change", model_id: model) if model && !session_manager.last_model_used
+        if reasoning && !session_manager.last_reasoning_level_used
+          publish_session_event(type: "reasoning_change", reasoning: reasoning)
+        end
+      end
+
+      def enqueue_or_run_message(message, queue, &block)
+        prepared_input = LlmGateway::Utils.deep_symbolize_keys(message)
+        result = session_manager.start_or_enqueue_user_message(prepared_input, queue: queue) do
+          compact_if_needed
+        end
+        return if result == session_manager.class::MESSAGE_QUEUED
+
+        begin
+          continue(&block)
+
+          loop do
+            break unless session_manager.queued_messages?(:next_turn)
+
+            compact_if_needed
+            drain_queue(:next_turn)
+            continue(&block)
+          end
+        ensure
+          session_manager.idle!
+        end
+      end
+
+      def compact_if_needed
+        compact if compaction_needed?
+      end
+
+      def compaction_needed?
+        session_manager.total_tokens > COMPACTION_TOKEN_THRESHOLD || last_assistant_message_stale?
+      end
+
+      def last_assistant_message_stale?
+        last_assistant_message_at = session_manager.last_assistant_message_at
+        last_assistant_message_at && Time.now - last_assistant_message_at > COMPACTION_IDLE_THRESHOLD_SECONDS
+      end
+
+      def drain_queue(queue)
+        session_manager.drain_message_queue(queue, mode: queue_drain_mode)
+      end
+
+      def emit(event, &block)
+        return unless block
+
+        block.call(event)
+      end
+    end
+  end
+end

--- a/lib/llm_gateway/agents/in_memory_session_manager.rb
+++ b/lib/llm_gateway/agents/in_memory_session_manager.rb
@@ -1,0 +1,222 @@
+# frozen_string_literal: true
+
+require "securerandom"
+require "time"
+
+module LlmGateway
+  module Agents
+    class InMemorySessionManager
+      MESSAGE_QUEUED = :queued
+      MESSAGE_STARTED = :started
+      QUEUES = [ :steer, :follow_up, :next_turn ].freeze
+      DRAIN_MODES = [ :one_at_a_time, :all ].freeze
+
+      attr_reader :session_id, :session_start
+
+      def initialize(session_id = nil)
+        @state = :idle
+        @session_id = session_id
+        @message_queues = Hash.new { |hash, key| hash[key] = [] }
+      end
+
+      def busy!
+        @state = :busy
+      end
+
+      def idle!
+        @state = :idle
+      end
+
+      def drain_message_queue(queue = :next_turn, mode: :all)
+        messages = queued_messages(queue, mode)
+        messages.each { |message| push_message(message) }
+        messages
+      end
+
+      def queued_messages?(queue = :next_turn)
+        @message_queues[validate_queue!(queue)].any?
+      end
+
+      def push_message_to_queue(message, queue = :next_turn)
+        @message_queues[validate_queue!(queue)] << message
+      end
+
+      def busy?
+        @state == :busy
+      end
+
+      def validate_queue!(queue)
+        queue = queue.to_sym
+        raise ArgumentError, "Invalid queue mode: #{queue}" unless QUEUES.include?(queue)
+
+        queue
+      end
+
+      def validate_drain_mode!(mode)
+        mode = mode.to_sym
+        raise ArgumentError, "Invalid queue drain mode: #{mode}" unless DRAIN_MODES.include?(mode)
+
+        mode
+      end
+
+      def start_or_enqueue_user_message(payload, queue: :next_turn)
+        if busy?
+          push_message_to_queue(payload, queue)
+          MESSAGE_QUEUED
+        else
+          yield if block_given?
+          push_message(payload)
+          busy!
+          MESSAGE_STARTED
+        end
+      end
+
+      def push_message(payload)
+        payload = payload.deep_symbolize_keys
+
+        push_entry(
+          type: "message",
+          usage: message_usage(payload),
+          data: payload,
+        )
+      end
+
+      def push_entry(entry)
+        id = SecureRandom.uuid
+        new_entry = {
+          id: id,
+          parent_id: parent_id_for_new_entry,
+          timestamp: Time.now.iso8601,
+          **entry
+        }
+
+        persist_entry(new_entry)
+        new_entry
+      end
+
+      def active_messages
+        active_message_events.map { |event| event[:data] }
+      end
+
+      def last_message_id
+        message_events.last&.dig(:id)
+      end
+
+      def last_model_used
+        events.reverse.find { |event| event[:type] == "model_change" }&.dig(:model_id)
+      end
+
+      def last_reasoning_level_used
+        events.reverse.find { |event| event[:type] == "reasoning_change" }&.dig(:reasoning)
+      end
+
+      def events_until(event_id)
+        index = events.index { |event| event[:id] == event_id }
+        raise ArgumentError, "Event not found in session: #{event_id}" unless index
+
+        events[0..index]
+      end
+
+      def events
+        @events ||= [ new_session_event ]
+      end
+
+      def build_model_input_messages
+        return active_messages unless last_compaction_entry
+
+        [ last_compaction_entry[:data], *active_messages ]
+      end
+
+      def total_tokens
+        entry = active_message_events.reverse.find { |event| event.dig(:usage, :total_tokens) }
+        entry&.dig(:usage, :total_tokens) || 0
+      end
+
+      def last_assistant_message_at
+        entry = active_message_events.reverse.find { |event| event.dig(:data, :role) == "assistant" }
+        Time.parse(entry[:timestamp]) if entry
+      end
+
+      def compaction(adapter)
+        response = adapter.stream(
+          active_messages,
+          system: "Summarize the conversation so far for future context.",
+          tools: []
+        )
+        message = response.to_h
+
+        push_entry(
+          type: "compaction",
+          usage: message_usage(message),
+          data: message
+        )
+      end
+
+      private
+
+      def queued_messages(queue, mode)
+        queue = validate_queue!(queue)
+        case validate_drain_mode!(mode)
+        when :one_at_a_time
+          message = @message_queues[queue].shift
+          message ? [ message ] : []
+        when :all
+          @message_queues[queue].shift(@message_queues[queue].length)
+        end
+      end
+
+      def parent_id_for_new_entry
+        events.length.positive? ? events.last[:id] : nil
+      end
+
+      def message_events
+        events.select { |event| event[:type] == "message" }
+      end
+
+      def active_message_events
+        compaction_event = last_compaction_entry
+        return message_events unless compaction_event
+
+        compaction_index = events.index(compaction_event)
+        events[(compaction_index + 1)..].select { |event| event[:type] == "message" }
+      end
+
+      def last_compaction_entry
+        events.reverse.find { |event| event[:type] == "compaction" }
+      end
+
+      def message_usage(message)
+        usage = message[:usage] || message["usage"]
+        return {} unless usage
+
+        usage.transform_keys(&:to_sym)
+      end
+
+      def persist_entry(entry)
+        attributes = {
+          session_id: @session_id,
+          position: next_position,
+          id: entry[:id],
+          parent_id: entry[:parent_id],
+          timestamp: entry[:timestamp],
+          type: entry[:type],
+          usage: entry[:usage],
+          data: entry[:data]
+        }
+
+        events << entry
+        attributes
+      end
+
+      def next_position
+        events.length
+      end
+
+      def new_session_event
+        @session_id ||= SecureRandom.uuid
+        @session_start = Time.now.strftime("%Y%m%d_%H%M%S")
+        { type: "session", id: session_id, timestamp: session_start }
+      end
+    end
+  end
+end

--- a/lib/llm_gateway/agents/tools/bash_tool.rb
+++ b/lib/llm_gateway/agents/tools/bash_tool.rb
@@ -1,0 +1,132 @@
+require "securerandom"
+require "tmpdir"
+require_relative "tool_utils"
+
+class BashTool < LlmGateway::Tool
+  # Pi adaptation notes:
+  # - Keep timeout schema as integer: gruv treats integer and number schemas equivalently for seconds.
+  # - Do not add pi's pluggable operations, shell/env hooks, command prefix, AbortSignal handling, partial updates, or UI render details: those are runtime/UI extension concerns outside this tool contract.
+  name "bash"
+  description "Execute a bash command in the current working directory. Returns stdout and stderr. Output is truncated to last #{ToolUtils::DEFAULT_MAX_LINES} lines or #{ToolUtils::DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first). If truncated, full output is saved to a temp file. Optionally provide a timeout in seconds."
+  input_schema({
+    type: "object",
+    properties: {
+      command: { type: "string", description: "Bash command to execute" },
+      timeout: { type: "integer", description: "Timeout in seconds (optional, no default timeout)" }
+    },
+    required: [ "command" ]
+  })
+
+  def execute(input)
+    command = input[:command]
+    timeout = input[:timeout]
+
+    result = run_command(command, timeout)
+    out = format_output(result[:output], empty_text: result[:timed_out] ? "" : "(no output)")
+
+    if result[:timed_out]
+      return append_status(out, "Command timed out after #{timeout} seconds")
+    end
+
+    if result[:exit_status] && result[:exit_status] != 0
+      return append_status(out, "Command exited with code #{result[:exit_status]}")
+    end
+
+    out
+  rescue StandardError => e
+    e.message
+  end
+
+  private
+
+  def run_command(command, timeout)
+    output = +""
+    timed_out = false
+    read_io, write_io = IO.pipe
+    pid = Process.spawn(command, chdir: Dir.pwd, in: File::NULL, out: write_io, err: write_io, pgroup: true)
+    write_io.close
+
+    deadline = timeout && timeout.positive? ? Time.now + timeout : nil
+
+    loop do
+      remaining = deadline ? deadline - Time.now : nil
+      if remaining && remaining <= 0
+        timed_out = true
+        terminate_process_group(pid)
+        break
+      end
+
+      ready = IO.select([ read_io ], nil, nil, remaining)
+      unless ready
+        timed_out = true
+        terminate_process_group(pid)
+        break
+      end
+
+      begin
+        output << read_io.readpartial(16 * 1024)
+      rescue EOFError
+        break
+      end
+    end
+
+    _, status = Process.wait2(pid)
+    drain_available_output(read_io, output)
+    read_io.close
+
+    { output: output, exit_status: status.exitstatus, timed_out: timed_out }
+  ensure
+    write_io.close if write_io && !write_io.closed?
+    read_io.close if read_io && !read_io.closed?
+  end
+
+  def drain_available_output(read_io, output)
+    loop do
+      ready = IO.select([ read_io ], nil, nil, 0.1)
+      break unless ready
+
+      begin
+        output << read_io.readpartial(16 * 1024)
+      rescue EOFError
+        break
+      end
+    end
+  end
+
+  def terminate_process_group(pid)
+    Process.kill("TERM", -pid)
+    sleep 0.1
+    Process.kill("KILL", -pid)
+  rescue Errno::ESRCH, Errno::EPERM
+    nil
+  end
+
+  def format_output(output, empty_text: "(no output)")
+    truncation = ToolUtils.truncate_tail(output)
+    out = truncation[:content]
+    out = empty_text if out.empty?
+
+    return out unless truncation[:truncated]
+
+    temp_path = File.join(Dir.tmpdir, "pi-bash-#{SecureRandom.hex(8)}.log")
+    File.write(temp_path, output)
+
+    start_line = truncation[:total_lines] - truncation[:output_lines] + 1
+    end_line = truncation[:total_lines]
+
+    notice = if truncation[:last_line_partial]
+      last_line = output.split("\n", -1).last
+      "[Showing last #{ToolUtils.format_size(truncation[:output_bytes])} of line #{end_line} (line is #{ToolUtils.format_size(last_line.bytesize)}). Full output: #{temp_path}]"
+    elsif truncation[:truncated_by] == "lines"
+      "[Showing lines #{start_line}-#{end_line} of #{truncation[:total_lines]}. Full output: #{temp_path}]"
+    else
+      "[Showing lines #{start_line}-#{end_line} of #{truncation[:total_lines]} (#{ToolUtils.format_size(ToolUtils::DEFAULT_MAX_BYTES)} limit). Full output: #{temp_path}]"
+    end
+
+    "#{out}\n\n#{notice}"
+  end
+
+  def append_status(text, status)
+    text.empty? ? status : "#{text}\n\n#{status}"
+  end
+end

--- a/lib/llm_gateway/agents/tools/edit_tool.rb
+++ b/lib/llm_gateway/agents/tools/edit_tool.rb
@@ -1,0 +1,215 @@
+require "json"
+require_relative "tool_utils"
+
+class EditTool < LlmGateway::Tool
+  # Pi adaptation notes:
+  # - Legacy single-edit input: pi accepts oldText/newText and converts to edits,
+  #   but this tool intentionally exposes/supports only the edits array to keep the LLM contract unambiguous.
+  # - Do not add pi's diff/patch details, preview rendering, pluggable operations, or AbortSignal handling: those are UI/runtime extension concerns outside this tool contract.
+  name "edit"
+
+  class EditError < StandardError; end
+  description "Edit a single file using exact text replacement. Every edits[].oldText must match a unique, non-overlapping region of the original file. If two changes affect the same block or nearby lines, merge them into one edit instead of emitting overlapping edits."
+  input_schema({
+    type: "object",
+    properties: {
+      path: { type: "string", description: "Path to the file to edit (relative or absolute)" },
+      edits: {
+        type: "array",
+        description: "One or more targeted replacements. Each edit is matched against the original file, not incrementally. Do not include overlapping or nested edits.",
+        items: {
+          type: "object",
+          properties: {
+            oldText: { type: "string", description: "Exact text for one targeted replacement. It must be unique in the original file and must not overlap with any other edits[].oldText in the same call." },
+            newText: { type: "string", description: "Replacement text for this targeted edit." }
+          },
+          required: [ "oldText", "newText" ]
+        }
+      }
+    },
+    required: [ "path", "edits" ]
+  })
+
+  def execute(input)
+    path = input[:path]
+    edits = prepare_edits(input[:edits])
+
+    return "Edit tool input is invalid. edits must contain at least one replacement." if !edits.is_a?(Array) || edits.empty?
+
+    absolute_path = ToolUtils.resolve_to_cwd(path)
+
+    ToolUtils.with_file_mutation_lock(absolute_path) do
+      begin
+        File.open(absolute_path, File::RDWR) { }
+      rescue SystemCallError => e
+        return "Could not edit file: #{path}. Error code: #{e.class.name.split("::").last}."
+      end
+
+      raw_content = File.binread(absolute_path)
+
+      bom = raw_content.start_with?("\xEF\xBB\xBF".b) ? "\xEF\xBB\xBF".b : "".b
+      content_without_bom = bom.empty? ? raw_content : raw_content.byteslice(3..)
+      content_utf8 = content_without_bom.force_encoding("UTF-8")
+
+      original_ending = detect_line_ending(content_utf8)
+      normalized_content = normalize_to_lf(content_utf8)
+      base_content, new_content = apply_edits_to_normalized_content(normalized_content, edits, path)
+
+      restored = restore_line_endings(new_content, original_ending)
+      final_bytes = bom + restored.encode("UTF-8").b
+
+      File.binwrite(absolute_path, final_bytes)
+      "Successfully replaced #{edits.length} block(s) in #{path}."
+    end
+  rescue EditError => e
+    e.message
+  rescue StandardError => e
+    "Error editing file: #{e.message}"
+  end
+
+  private
+
+  def prepare_edits(edits)
+    return JSON.parse(edits, symbolize_names: true) if edits.is_a?(String)
+
+    edits
+  end
+
+  def detect_line_ending(content)
+    crlf_index = content.index("\r\n")
+    lf_index = content.index("\n")
+    return "\n" unless lf_index
+    return "\n" unless crlf_index
+
+    crlf_index < lf_index ? "\r\n" : "\n"
+  end
+
+  def normalize_to_lf(text)
+    text.gsub("\r\n", "\n").gsub("\r", "\n")
+  end
+
+  def restore_line_endings(text, ending)
+    ending == "\r\n" ? text.gsub("\n", "\r\n") : text
+  end
+
+  def normalize_for_fuzzy_match(text)
+    text
+      .unicode_normalize(:nfkc)
+      .split("\n", -1)
+      .map(&:rstrip)
+      .join("\n")
+      .gsub(/[\u2018\u2019\u201A\u201B]/, "'")
+      .gsub(/[\u201C\u201D\u201E\u201F]/, '"')
+      .gsub(/[\u2010\u2011\u2012\u2013\u2014\u2015\u2212]/, "-")
+      .gsub(/[\u00A0\u2002-\u200A\u202F\u205F\u3000]/, " ")
+  end
+
+  def fuzzy_find_text(content, old_text)
+    exact_index = content.index(old_text)
+    if exact_index
+      return {
+        found: true,
+        index: exact_index,
+        match_length: old_text.length,
+        used_fuzzy_match: false,
+        content_for_replacement: content
+      }
+    end
+
+    fuzzy_content = normalize_for_fuzzy_match(content)
+    fuzzy_old_text = normalize_for_fuzzy_match(old_text)
+    fuzzy_index = fuzzy_content.index(fuzzy_old_text)
+
+    return { found: false, index: -1, match_length: 0, used_fuzzy_match: false, content_for_replacement: content } unless fuzzy_index
+
+    {
+      found: true,
+      index: fuzzy_index,
+      match_length: fuzzy_old_text.length,
+      used_fuzzy_match: true,
+      content_for_replacement: fuzzy_content
+    }
+  end
+
+  def count_occurrences(content, old_text)
+    fuzzy_content = normalize_for_fuzzy_match(content)
+    fuzzy_old_text = normalize_for_fuzzy_match(old_text)
+    fuzzy_content.split(fuzzy_old_text, -1).length - 1
+  end
+
+  def apply_edits_to_normalized_content(normalized_content, edits, path)
+    normalized_edits = edits.map do |edit|
+      {
+        oldText: normalize_to_lf(edit[:oldText]),
+        newText: normalize_to_lf(edit[:newText])
+      }
+    end
+
+    normalized_edits.each_with_index do |edit, index|
+      raise EditError, empty_old_text_error(path, index, normalized_edits.length) if edit[:oldText].empty?
+    end
+
+    initial_matches = normalized_edits.map { |edit| fuzzy_find_text(normalized_content, edit[:oldText]) }
+    base_content = initial_matches.any? { |match| match[:used_fuzzy_match] } ? normalize_for_fuzzy_match(normalized_content) : normalized_content
+
+    matched_edits = []
+    normalized_edits.each_with_index do |edit, index|
+      match = fuzzy_find_text(base_content, edit[:oldText])
+      raise EditError, not_found_error(path, index, normalized_edits.length) unless match[:found]
+
+      occurrences = count_occurrences(base_content, edit[:oldText])
+      raise EditError, duplicate_error(path, index, normalized_edits.length, occurrences) if occurrences > 1
+
+      matched_edits << {
+        edit_index: index,
+        match_index: match[:index],
+        match_length: match[:match_length],
+        new_text: edit[:newText]
+      }
+    end
+
+    matched_edits.sort_by! { |edit| edit[:match_index] }
+    matched_edits.each_cons(2) do |previous, current|
+      next unless previous[:match_index] + previous[:match_length] > current[:match_index]
+
+      raise EditError, "edits[#{previous[:edit_index]}] and edits[#{current[:edit_index]}] overlap in #{path}. Merge them into one edit or target disjoint regions."
+    end
+
+    new_content = base_content.dup
+    matched_edits.reverse_each do |edit|
+      new_content = new_content[0...edit[:match_index]] + edit[:new_text] + new_content[(edit[:match_index] + edit[:match_length])..]
+    end
+
+    raise EditError, no_change_error(path, normalized_edits.length) if base_content == new_content
+
+    [ base_content, new_content ]
+  end
+
+  def not_found_error(path, edit_index, total_edits)
+    return "Could not find the exact text in #{path}. The old text must match exactly including all whitespace and newlines." if total_edits == 1
+
+    "Could not find edits[#{edit_index}] in #{path}. The oldText must match exactly including all whitespace and newlines."
+  end
+
+  def duplicate_error(path, edit_index, total_edits, occurrences)
+    if total_edits == 1
+      return "Found #{occurrences} occurrences of the text in #{path}. The text must be unique. Please provide more context to make it unique."
+    end
+
+    "Found #{occurrences} occurrences of edits[#{edit_index}] in #{path}. Each oldText must be unique. Please provide more context to make it unique."
+  end
+
+  def empty_old_text_error(path, edit_index, total_edits)
+    return "oldText must not be empty in #{path}." if total_edits == 1
+
+    "edits[#{edit_index}].oldText must not be empty in #{path}."
+  end
+
+  def no_change_error(path, total_edits)
+    if total_edits == 1
+      return "No changes made to #{path}. The replacement produced identical content. This might indicate an issue with special characters or the text not existing as expected."
+    end
+
+    "No changes made to #{path}. The replacements produced identical content."
+  end
+end

--- a/lib/llm_gateway/agents/tools/read_tool.rb
+++ b/lib/llm_gateway/agents/tools/read_tool.rb
@@ -1,0 +1,143 @@
+require "base64"
+require_relative "tool_utils"
+
+class ReadTool < LlmGateway::Tool
+  # Pi adaptation notes:
+  # - Keep offset/limit schema as integer: gruv treats integer and number schemas equivalently for line counts.
+  # - Do not add pi's image resize/model-omission behavior: current LLMs allow larger images than pi's conservative limit, and gruv tools do not receive model capability context.
+  # - Do not add pi's compact read UI, pluggable operations, AbortSignal handling, or details metadata: those are UI/runtime extension concerns outside this tool contract.
+  name "read"
+  description "Read the contents of a file. Supports text files and images (jpg, png, gif, webp). Images are sent as attachments. For text files, output is truncated to #{ToolUtils::DEFAULT_MAX_LINES} lines or #{ToolUtils::DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first). Use offset/limit for large files. When you need the full file, continue with offset until complete."
+  input_schema({
+    type: "object",
+    properties: {
+      path: { type: "string", description: "Path to the file to read (relative or absolute)" },
+      offset: { type: "integer", description: "Line number to start reading from (1-indexed)" },
+      limit: { type: "integer", description: "Maximum number of lines to read" }
+    },
+    required: [ "path" ]
+  })
+
+  IMAGE_TYPE_SNIFF_BYTES = 4100
+  PNG_SIGNATURE = [ 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a ].freeze
+
+  def execute(input)
+    path = input[:path] || input["path"]
+    offset = input[:offset] || input["offset"]
+    limit = input[:limit] || input["limit"]
+
+    absolute_path = ToolUtils.resolve_read_path(path)
+
+    return "File not found: #{path}" unless File.exist?(absolute_path)
+    return "Cannot read directory: #{path}" if File.directory?(absolute_path)
+    return "File is not readable: #{path}" unless File.readable?(absolute_path)
+
+    mime_type = detect_supported_image_mime_type_from_file(absolute_path)
+    if mime_type
+      data = Base64.strict_encode64(File.binread(absolute_path))
+      return [
+        { type: "text", text: "Read image file [#{mime_type}]" },
+        { type: "image", data: data, media_type: mime_type }
+      ]
+    end
+
+    content = File.read(absolute_path, mode: "r:bom|utf-8")
+    all_lines = content.split("\n", -1)
+    total_file_lines = all_lines.length
+
+    start_line = [ 0, (offset || 1).to_i - 1 ].max
+    return "Offset #{offset} is beyond end of file (#{all_lines.length} lines total)" if start_line >= all_lines.length
+
+    selected_content = if limit
+      end_line = [ start_line + limit.to_i, all_lines.length ].min
+      all_lines[start_line...end_line].join("\n")
+    else
+      all_lines[start_line..].join("\n")
+    end
+
+    truncation = ToolUtils.truncate_head(selected_content)
+    start_display = start_line + 1
+
+    if truncation[:first_line_exceeds_limit]
+      first_line_size = ToolUtils.format_size(all_lines[start_line].to_s.bytesize)
+      return "[Line #{start_display} is #{first_line_size}, exceeds #{ToolUtils.format_size(ToolUtils::DEFAULT_MAX_BYTES)} limit. Use bash: sed -n '#{start_display}p' #{path} | head -c #{ToolUtils::DEFAULT_MAX_BYTES}]"
+    end
+
+    output = truncation[:content]
+
+    if truncation[:truncated]
+      end_display = start_display + truncation[:output_lines] - 1
+      next_offset = end_display + 1
+      suffix = if truncation[:truncated_by] == "lines"
+        "[Showing lines #{start_display}-#{end_display} of #{total_file_lines}. Use offset=#{next_offset} to continue.]"
+      else
+        "[Showing lines #{start_display}-#{end_display} of #{total_file_lines} (#{ToolUtils.format_size(ToolUtils::DEFAULT_MAX_BYTES)} limit). Use offset=#{next_offset} to continue.]"
+      end
+      output = "#{output}\n\n#{suffix}"
+    elsif limit && (start_line + limit.to_i) < all_lines.length
+      next_offset = start_line + limit.to_i + 1
+      remaining = all_lines.length - (start_line + limit.to_i)
+      output = "#{output}\n\n[#{remaining} more lines in file. Use offset=#{next_offset} to continue.]"
+    end
+
+    output
+  rescue StandardError => e
+    "Error reading file: #{e.message}"
+  end
+
+  private
+
+  def detect_supported_image_mime_type_from_file(path)
+    detect_supported_image_mime_type(File.binread(path, IMAGE_TYPE_SNIFF_BYTES))
+  end
+
+  def detect_supported_image_mime_type(buffer)
+    bytes = buffer.bytes
+    return "image/jpeg" if jpeg?(bytes)
+    return "image/png" if png?(bytes) && !animated_png?(bytes)
+    return "image/gif" if ascii_at?(bytes, 0, "GIF")
+    return "image/webp" if ascii_at?(bytes, 0, "RIFF") && ascii_at?(bytes, 8, "WEBP")
+
+    nil
+  end
+
+  def jpeg?(bytes)
+    bytes.length >= 4 && bytes[0] == 0xff && bytes[1] == 0xd8 && bytes[2] == 0xff && bytes[3] != 0xf7
+  end
+
+  def png?(bytes)
+    starts_with?(bytes, PNG_SIGNATURE) && bytes.length >= 16 && read_uint32_be(bytes, PNG_SIGNATURE.length) == 13 && ascii_at?(bytes, 12, "IHDR")
+  end
+
+  def animated_png?(bytes)
+    offset = PNG_SIGNATURE.length
+    while offset + 8 <= bytes.length
+      chunk_length = read_uint32_be(bytes, offset)
+      chunk_type_offset = offset + 4
+      return true if ascii_at?(bytes, chunk_type_offset, "acTL")
+      return false if ascii_at?(bytes, chunk_type_offset, "IDAT")
+
+      next_offset = offset + 8 + chunk_length + 4
+      return false if next_offset <= offset || next_offset > bytes.length
+
+      offset = next_offset
+    end
+    false
+  end
+
+  def read_uint32_be(bytes, offset)
+    ((bytes[offset] || 0) << 24) + ((bytes[offset + 1] || 0) << 16) + ((bytes[offset + 2] || 0) << 8) + (bytes[offset + 3] || 0)
+  end
+
+  def starts_with?(bytes, prefix)
+    return false if bytes.length < prefix.length
+
+    prefix.each_with_index.all? { |byte, index| bytes[index] == byte }
+  end
+
+  def ascii_at?(bytes, offset, text)
+    return false if bytes.length < offset + text.length
+
+    text.bytes.each_with_index.all? { |byte, index| bytes[offset + index] == byte }
+  end
+end

--- a/lib/llm_gateway/agents/tools/tool_utils.rb
+++ b/lib/llm_gateway/agents/tools/tool_utils.rb
@@ -1,0 +1,164 @@
+require "pathname"
+require "thread"
+
+module ToolUtils
+  DEFAULT_MAX_LINES = 2000
+  DEFAULT_MAX_BYTES = 50 * 1024
+
+  @file_mutation_locks = Hash.new { |hash, key| hash[key] = Mutex.new }
+  @file_mutation_locks_mutex = Mutex.new
+
+  module_function
+
+  def with_file_mutation_lock(path)
+    lock = @file_mutation_locks_mutex.synchronize { @file_mutation_locks[path] }
+    lock.synchronize { yield }
+  end
+
+  def format_size(bytes)
+    return "#{bytes}B" if bytes < 1024
+    return format("%.1fKB", bytes / 1024.0) if bytes < 1024 * 1024
+
+    format("%.1fMB", bytes / (1024.0 * 1024.0))
+  end
+
+  def expand_path(file_path)
+    normalized = file_path.to_s.sub(/^@/, "").gsub(/[\u00A0\u2000-\u200A\u202F\u205F\u3000]/, " ")
+    return Dir.home if normalized == "~"
+    return File.join(Dir.home, normalized[2..]) if normalized.start_with?("~/")
+
+    normalized
+  end
+
+  def resolve_to_cwd(file_path, cwd = Dir.pwd)
+    expanded = expand_path(file_path)
+    Pathname.new(expanded).absolute? ? expanded : File.expand_path(expanded, cwd)
+  end
+
+  def resolve_read_path(file_path, cwd = Dir.pwd)
+    resolved = resolve_to_cwd(file_path, cwd)
+    return resolved if File.exist?(resolved)
+
+    am_pm_variant = resolved.gsub(/ (AM|PM)\./i) { "\u202F#{Regexp.last_match(1)}." }
+    return am_pm_variant if File.exist?(am_pm_variant)
+
+    nfd_variant = resolved.unicode_normalize(:nfd)
+    return nfd_variant if File.exist?(nfd_variant)
+
+    curly_variant = resolved.tr("'", "\u2019")
+    return curly_variant if File.exist?(curly_variant)
+
+    nfd_curly_variant = nfd_variant.tr("'", "\u2019")
+    return nfd_curly_variant if File.exist?(nfd_curly_variant)
+
+    resolved
+  end
+
+  def truncate_head(content, max_lines: DEFAULT_MAX_LINES, max_bytes: DEFAULT_MAX_BYTES)
+    lines = split_lines_for_counting(content)
+    total_lines = lines.length
+    total_bytes = content.bytesize
+
+    if total_lines <= max_lines && total_bytes <= max_bytes
+      return truncation_result(content, false, nil, total_lines, total_bytes, total_lines, total_bytes, false, false, max_lines, max_bytes)
+    end
+
+    first_line_bytes = lines.first.to_s.bytesize
+    if first_line_bytes > max_bytes
+      return truncation_result("", true, "bytes", total_lines, total_bytes, 0, 0, false, true, max_lines, max_bytes)
+    end
+
+    out_lines = []
+    out_bytes = 0
+    truncated_by = "lines"
+
+    lines.each_with_index do |line, index|
+      break if index >= max_lines
+
+      line_bytes = line.bytesize + (index.positive? ? 1 : 0)
+      if out_bytes + line_bytes > max_bytes
+        truncated_by = "bytes"
+        break
+      end
+
+      out_lines << line
+      out_bytes += line_bytes
+    end
+
+    output = out_lines.join("\n")
+    truncation_result(output, true, truncated_by, total_lines, total_bytes, out_lines.length, output.bytesize, false, false, max_lines, max_bytes)
+  end
+
+  def truncate_tail(content, max_lines: DEFAULT_MAX_LINES, max_bytes: DEFAULT_MAX_BYTES)
+    lines = split_lines_for_counting(content)
+    total_lines = lines.length
+    total_bytes = content.bytesize
+
+    if total_lines <= max_lines && total_bytes <= max_bytes
+      return truncation_result(content, false, nil, total_lines, total_bytes, total_lines, total_bytes, false, false, max_lines, max_bytes)
+    end
+
+    out_lines = []
+    out_bytes = 0
+    truncated_by = "lines"
+    last_line_partial = false
+
+    (lines.length - 1).downto(0) do |i|
+      break if out_lines.length >= max_lines
+
+      line = lines[i]
+      line_bytes = line.bytesize + (out_lines.empty? ? 0 : 1)
+
+      if out_bytes + line_bytes > max_bytes
+        truncated_by = "bytes"
+        if out_lines.empty?
+          out_lines.unshift(truncate_string_to_bytes_from_end(line, max_bytes))
+          out_bytes = out_lines.first.bytesize
+          last_line_partial = true
+        end
+        break
+      end
+
+      out_lines.unshift(line)
+      out_bytes += line_bytes
+    end
+
+    output = out_lines.join("\n")
+    truncation_result(output, true, truncated_by, total_lines, total_bytes, out_lines.length, output.bytesize, last_line_partial, false, max_lines, max_bytes)
+  end
+
+  def split_lines_for_counting(content)
+    return [] if content.empty?
+
+    lines = content.split("\n", -1)
+    lines.pop if content.end_with?("\n")
+    lines
+  end
+
+  def truncation_result(content, truncated, truncated_by, total_lines, total_bytes, output_lines, output_bytes, last_line_partial, first_line_exceeds_limit, max_lines, max_bytes)
+    {
+      content: content,
+      truncated: truncated,
+      truncated_by: truncated_by,
+      total_lines: total_lines,
+      total_bytes: total_bytes,
+      output_lines: output_lines,
+      output_bytes: output_bytes,
+      last_line_partial: last_line_partial,
+      first_line_exceeds_limit: first_line_exceeds_limit,
+      max_lines: max_lines,
+      max_bytes: max_bytes
+    }
+  end
+
+  def truncate_string_to_bytes_from_end(str, max_bytes)
+    bytes = str.dup.force_encoding("UTF-8").bytes
+    return str if bytes.length <= max_bytes
+
+    tail = bytes.last(max_bytes).pack("C*")
+    until tail.valid_encoding?
+      tail = tail.bytes.drop(1).pack("C*")
+    end
+    tail
+  end
+end

--- a/lib/llm_gateway/agents/tools/write_tool.rb
+++ b/lib/llm_gateway/agents/tools/write_tool.rb
@@ -1,0 +1,34 @@
+require "fileutils"
+require_relative "tool_utils"
+
+class WriteTool < LlmGateway::Tool
+  # Pi adaptation notes:
+  # - Keep Ruby bytesize in the success message rather than pi's JS string length; the byte count is more accurate for UTF-8 content.
+  # - Do not add pi's pluggable operations, AbortSignal handling, render previews, or details metadata: those are UI/runtime extension concerns outside this tool contract.
+  name "write"
+  description "Write content to a file. Creates the file if it doesn't exist, overwrites if it does. Automatically creates parent directories."
+  input_schema({
+    type: "object",
+    properties: {
+      path: { type: "string", description: "Path to the file to write (relative or absolute)" },
+      content: { type: "string", description: "Content to write to the file" }
+    },
+    required: [ "path", "content" ]
+  })
+
+  def execute(input)
+    path = input[:path] || input["path"]
+    content = input[:content] || input["content"]
+
+    absolute_path = ToolUtils.resolve_to_cwd(path)
+
+    ToolUtils.with_file_mutation_lock(absolute_path) do
+      FileUtils.mkdir_p(File.dirname(absolute_path))
+      File.write(absolute_path, content)
+    end
+
+    "Successfully wrote #{content.bytesize} bytes to #{path}"
+  rescue StandardError => e
+    e.message
+  end
+end

--- a/lib/llm_gateway/utils.rb
+++ b/lib/llm_gateway/utils.rb
@@ -50,45 +50,47 @@ module LlmGateway
   end
 end
 
-class Class
-  def class_attribute(*names, instance_accessor: true, instance_reader: instance_accessor, instance_writer: instance_accessor, instance_predicate: true, default: nil)
-    names.each do |name|
-      ivar = :"@#{name}"
-      instance_variable_set(ivar, default)
+unless Class.method_defined?(:class_attribute)
+  class Class
+    def class_attribute(*names, instance_accessor: true, instance_reader: instance_accessor, instance_writer: instance_accessor, instance_predicate: true, default: nil)
+      names.each do |name|
+        ivar = :"@#{name}"
+        instance_variable_set(ivar, default)
 
-      unset = Object.new
+        unset = Object.new
 
-      define_singleton_method(name) do |value = unset|
-        unless value.equal?(unset)
-          instance_variable_set(ivar, value)
-          next value
-        end
+        define_singleton_method(name) do |value = unset|
+          unless value.equal?(unset)
+            instance_variable_set(ivar, value)
+            next value
+          end
 
-        if instance_variable_defined?(ivar)
-          instance_variable_get(ivar)
-        elsif superclass.respond_to?(name)
-          superclass.public_send(name)
-        end
-      end
-
-      define_singleton_method("#{name}=") do |value|
-        instance_variable_set(ivar, value)
-      end
-
-      if instance_reader
-        define_method(name) do
           if instance_variable_defined?(ivar)
             instance_variable_get(ivar)
-          else
-            self.class.public_send(name)
+          elsif superclass.respond_to?(name)
+            superclass.public_send(name)
           end
         end
-      end
 
-      define_method("#{name}=") { |value| instance_variable_set(ivar, value) } if instance_writer
+        define_singleton_method("#{name}=") do |value|
+          instance_variable_set(ivar, value)
+        end
 
-      if instance_predicate
-        define_method("#{name}?") { !!public_send(name) }
+        define_singleton_method("#{name}?") { !!public_send(name) } if instance_predicate
+
+        if instance_reader
+          define_method(name) do
+            if instance_variable_defined?(ivar)
+              instance_variable_get(ivar)
+            else
+              self.class.public_send(name)
+            end
+          end
+        end
+
+        define_method("#{name}=") { |value| instance_variable_set(ivar, value) } if instance_writer
+
+        define_method("#{name}?") { !!public_send(name) } if instance_predicate
       end
     end
   end

--- a/test/integration/harness_in_memory_session_test.rb
+++ b/test/integration/harness_in_memory_session_test.rb
@@ -1,0 +1,611 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "llm_gateway/agents/harness"
+require "llm_gateway/agents/in_memory_session_manager"
+
+
+class HarnessInMemorySessionIntegrationTest < Test
+  class TestHarness < LlmGateway::Agents::Harness
+    TOOLS = []
+  end
+
+  class AddTool < LlmGateway::Tool
+    name "add"
+    description "Adds two numbers"
+    input_schema({ type: "object" })
+
+    def execute(input)
+      input.fetch(:left) + input.fetch(:right)
+    end
+  end
+
+  class ExplodingTool < LlmGateway::Tool
+    name "explode"
+    description "Raises an error"
+    input_schema({ type: "object" })
+
+    def execute(_input)
+      raise "boom"
+    end
+  end
+
+  class ToolHarness < LlmGateway::Agents::Harness
+    TOOLS = [ AddTool, ExplodingTool ]
+  end
+
+  FakeInnerClient = Struct.new(:model_key)
+
+  class FakeAdapter
+    attr_reader :client, :calls
+
+    def initialize(responses)
+      @client = FakeInnerClient.new("fake-model")
+      @responses = responses.dup
+      @calls = []
+    end
+
+    def stream(messages, **options)
+      @calls << { messages: Marshal.load(Marshal.dump(messages)), options: options }
+      if block_given?
+        yield AssistantStreamEvent.new(
+          type: :text_delta,
+          content_index: 0,
+          delta: "streamed",
+          partial: PartialAssistantMessage.new(timestamp: 1_716_650_000_000)
+        )
+      end
+      @responses.shift || assistant_message("fallback")
+    end
+  end
+
+  def assistant_message(text, total_tokens: 10, id: nil)
+    assistant_message_with_content(
+      [ { type: "text", text: text } ],
+      total_tokens: total_tokens,
+      id: id || "msg_#{text.gsub(/\W+/, "_")}",
+      stop_reason: "stop"
+    )
+  end
+
+  def assistant_tool_message(tool_name, input, id: nil, tool_use_id: nil)
+    assistant_message_with_content(
+      [ { id: tool_use_id || "toolu_#{tool_name}", type: "tool_use", name: tool_name, input: input } ],
+      id: id || "msg_tool_#{tool_name}",
+      stop_reason: "tool_use"
+    )
+  end
+
+  def assistant_message_with_content(content, total_tokens: 10, id:, stop_reason:)
+    AssistantMessage.new(
+      id: id,
+      model: "fake-model",
+      usage: { input_tokens: 1, output_tokens: 2, total_tokens: total_tokens },
+      role: "assistant",
+      timestamp: 1_716_650_000_000,
+      stop_reason: stop_reason,
+      provider: "fake",
+      api: "fake",
+      content: content
+    )
+  end
+
+  def user_message(text)
+    { role: "user", content: [ { type: "text", text: text } ] }
+  end
+
+  def stored_assistant_message(text, total_tokens: 10, id: nil)
+    stored_message(assistant_message(text, total_tokens: total_tokens, id: id))
+  end
+
+  def stored_message(message)
+    message.to_h
+  end
+
+  def compacted_assistant_message(text, total_tokens: 10, id: nil)
+    stored_assistant_message(text, total_tokens: total_tokens, id: id)
+  end
+
+  def new_harness(responses, harness_class: TestHarness, model: nil)
+    session = LlmGateway::Agents::InMemorySessionManager.new("test-session")
+    adapter = FakeAdapter.new(responses)
+    [ harness_class.new(session, provider: adapter, model: model), session, adapter ]
+  end
+
+  test "creates an in-memory session with a session event and adds messages directly when active" do
+    harness, session, client = new_harness([ assistant_message("hello back") ])
+
+    harness.prompt_message(user_message("hello"))
+
+    assert_equal "test-session", session.session_id
+    assert_equal "session", session.events.first[:type]
+    assert_equal "test-session", session.events.first[:id]
+    assert_equal [ user_message("hello") ], client.calls.first[:messages]
+    assert_equal [ user_message("hello"), stored_assistant_message("hello back") ], session.active_messages
+  end
+
+  test "accepts and normalizes string-keyed LLM-shaped messages" do
+    harness, session, client = new_harness([ assistant_message("hello back") ])
+    input = {
+      "role" => "user",
+      "content" => [ { "type" => "text", "text" => "hello" } ]
+    }
+
+    harness.prompt_message(input)
+
+    assert_equal [ user_message("hello") ], client.calls.first[:messages]
+    assert_equal [ user_message("hello"), stored_assistant_message("hello back") ], session.active_messages
+  end
+
+  test "accepts an LLM-shaped content array including images" do
+    harness, session, client = new_harness([ assistant_message("image answer") ])
+    message = {
+      role: "user",
+      content: [
+        { type: "text", text: "What do you see in this image?" },
+        { type: "image", data: "image_b64", media_type: "image/png" }
+      ]
+    }
+
+    harness.prompt_message(message)
+
+    assert_equal [ message ], client.calls.first[:messages]
+    assert_equal [ message, stored_assistant_message("image answer") ], session.active_messages
+  end
+
+  test "emits harness events in lifecycle order while streaming" do
+    harness, _session, = new_harness([ assistant_message("hello back") ])
+    events = []
+
+    harness.prompt_message(user_message("hello")) { |event| events << event.type }
+
+    assert_equal [
+      :agent_start,
+      :turn_start,
+      :message_start,
+      :message_update,
+      :message_end,
+      :turn_end,
+      :agent_end
+    ], events
+  end
+
+  test "accepts model and reasoning options at initialization" do
+    session = LlmGateway::Agents::InMemorySessionManager.new("test-session")
+    adapter = FakeAdapter.new([ assistant_message("hello back") ])
+    harness = TestHarness.new(
+      session,
+      provider: adapter,
+      model: "initial-model",
+      reasoning: "low"
+    )
+
+    harness.prompt_message(user_message("hello"))
+
+    assert_equal "initial-model", harness.model
+    assert_equal "low", harness.reasoning
+    assert_equal adapter, harness.provider
+    assert_equal "initial-model", adapter.calls.first[:options][:model]
+    assert_equal "low", adapter.calls.first[:options][:reasoning]
+  end
+
+  test "initialization publishes model and reasoning events when there is no transcript" do
+    session = LlmGateway::Agents::InMemorySessionManager.new("test-session")
+    adapter = FakeAdapter.new([])
+
+    TestHarness.new(session, provider: adapter, model: "initial-model", reasoning: "low")
+
+    model_event = session.events.find { |entry| entry[:type] == "model_change" }
+    reasoning_event = session.events.find { |entry| entry[:type] == "reasoning_change" }
+    assert_equal "initial-model", model_event[:model_id]
+    assert_equal "low", reasoning_event[:reasoning]
+    assert model_event[:id]
+    assert reasoning_event[:id]
+    assert_equal session.events.first[:id], model_event[:parent_id]
+    assert_equal model_event[:id], reasoning_event[:parent_id]
+  end
+
+  test "session reports last model and reasoning by walking back configuration events" do
+    session = LlmGateway::Agents::InMemorySessionManager.new("test-session")
+
+    session.push_entry(type: "model_change", model_id: "first-model")
+    session.push_entry(type: "reasoning_change", reasoning: "low")
+    session.push_message(user_message("existing"))
+    session.push_entry(type: "model_change", model_id: "last-model")
+    session.push_entry(type: "reasoning_change", reasoning: "high")
+
+    assert_equal "last-model", session.last_model_used
+    assert_equal "high", session.last_reasoning_level_used
+  end
+
+  test "initialization does not publish model and reasoning events when transcript matches" do
+    session = LlmGateway::Agents::InMemorySessionManager.new("test-session")
+    adapter = FakeAdapter.new([])
+    session.push_entry(type: "model_change", model_id: "initial-model")
+    session.push_entry(type: "reasoning_change", reasoning: "low")
+    session.push_message(user_message("existing"))
+    events_before = session.events.dup
+
+    TestHarness.new(session, provider: adapter, model: "initial-model", reasoning: "low")
+
+    assert_equal events_before, session.events
+  end
+
+  test "initialization does not publish model and reasoning events when transcript already has configuration" do
+    session = LlmGateway::Agents::InMemorySessionManager.new("test-session")
+    adapter = FakeAdapter.new([])
+    session.push_entry(type: "model_change", model_id: "old-model")
+    session.push_entry(type: "reasoning_change", reasoning: "low")
+    session.push_message(user_message("existing"))
+    events_before = session.events.dup
+
+    TestHarness.new(session, provider: adapter, model: "new-model", reasoning: "high")
+
+    assert_equal events_before, session.events
+  end
+
+  test "loaded transcript with different model and reasoning does not publish duplicate configuration events" do
+    session = LlmGateway::Agents::InMemorySessionManager.new("test-session")
+    adapter = FakeAdapter.new([ assistant_message("hello back") ])
+    session.push_entry(type: "model_change", model_id: "transcript-model")
+    session.push_entry(type: "reasoning_change", reasoning: "low")
+    session.push_message(user_message("existing"))
+    events_before = session.events.dup
+
+    harness = TestHarness.new(session, provider: adapter, model: "configured-model", reasoning: "high")
+    harness.prompt_message(user_message("next"))
+
+    assert_equal events_before, session.events.first(events_before.length)
+    assert_equal 1, session.events.count { |entry| entry[:type] == "model_change" }
+    assert_equal 1, session.events.count { |entry| entry[:type] == "reasoning_change" }
+    assert_equal "configured-model", adapter.calls.first[:options][:model]
+    assert_equal "high", adapter.calls.first[:options][:reasoning]
+  end
+
+  test "publishes model changes to the session and uses the model for streaming" do
+    harness, session, client = new_harness([ assistant_message("hello back") ], model: "fake-model")
+
+    harness.model = "fake-model-2"
+    harness.model = "fake-model-2"
+    harness.prompt_message(user_message("hello"))
+
+    event = session.events.reverse.find { |entry| entry[:type] == "model_change" }
+    assert_equal "fake-model-2", harness.model
+    assert_equal "model_change", event[:type]
+    assert_equal "fake-model-2", event[:model_id]
+    assert event[:id]
+    assert event[:timestamp]
+    assert_equal 2, session.events.count { |entry| entry[:type] == "model_change" }
+    assert_equal "fake-model-2", client.calls.first[:options][:model]
+  end
+
+  test "publishes reasoning changes to the session and uses the level for streaming" do
+    harness, session, client = new_harness([ assistant_message("hello back") ])
+
+    harness.reasoning = "medium"
+    harness.reasoning = "medium"
+    harness.prompt_message(user_message("hello"))
+
+    event = session.events.reverse.find { |entry| entry[:type] == "reasoning_change" }
+    assert_equal "medium", harness.reasoning
+    assert_equal "reasoning_change", event[:type]
+    assert_equal "medium", event[:reasoning]
+    assert event[:id]
+    assert event[:timestamp]
+    assert_equal 2, session.events.count { |entry| entry[:type] == "reasoning_change" }
+    assert_equal "medium", client.calls.first[:options][:reasoning]
+  end
+
+  test "queues prompt messages as next turn by default and drains all queued messages together" do
+    harness, session, client = new_harness([
+      assistant_message("first response", id: "assistant_1"),
+      assistant_message("second response", id: "assistant_2")
+    ])
+
+    queued = false
+    harness.prompt_message(user_message("first")) do |event|
+      next if queued || event.type != :agent_start
+
+      queued = true
+      harness.prompt_message(user_message("queued one"))
+      harness.prompt_message(user_message("queued two"))
+    end
+
+    assert_equal 2, client.calls.size
+    assert_equal [ user_message("first") ], client.calls[0][:messages]
+    assert_equal [
+      user_message("first"),
+      stored_assistant_message("first response", id: "assistant_1"),
+      user_message("queued one"),
+      user_message("queued two")
+    ], client.calls[1][:messages]
+
+    assert_equal [ "first", "first response", "queued one", "queued two", "second response" ],
+      session.active_messages.map { |message| message.dig(:content, 0, :text) }
+  end
+
+  test "allows changing the default busy prompt queue" do
+    harness, _session, client = new_harness([
+      assistant_message("first response", id: "assistant_1"),
+      assistant_message("follow up response", id: "assistant_2")
+    ])
+    harness.default_queue_mode = :follow_up
+
+    queued = false
+    harness.prompt_message(user_message("first")) do |event|
+      next if queued || event.type != :agent_start
+
+      queued = true
+      harness.prompt_message(user_message("queued prompt"))
+    end
+
+    assert_equal 2, client.calls.size
+    assert_equal [
+      user_message("first"),
+      stored_assistant_message("first response", id: "assistant_1"),
+      user_message("queued prompt")
+    ], client.calls[1][:messages]
+  end
+
+  test "symbolizes string-keyed messages when draining queued prompts" do
+    harness, _session, client = new_harness([
+      assistant_message("first response", id: "assistant_1"),
+      assistant_message("follow up response", id: "assistant_2")
+    ])
+    harness.default_queue_mode = :follow_up
+    string_keyed_message = {
+      "role" => "user",
+      "content" => [ { "type" => "text", "text" => "queued prompt" } ]
+    }
+
+    queued = false
+    harness.prompt_message(user_message("first")) do |event|
+      next if queued || event.type != :agent_start
+
+      queued = true
+      harness.prompt_message(string_keyed_message)
+    end
+
+    assert_equal [
+      user_message("first"),
+      stored_assistant_message("first response", id: "assistant_1"),
+      user_message("queued prompt")
+    ], client.calls[1][:messages]
+  end
+
+  test "can drain next turn queue one at a time" do
+    harness, _session, client = new_harness([
+      assistant_message("first response", id: "assistant_1"),
+      assistant_message("second response", id: "assistant_2"),
+      assistant_message("third response", id: "assistant_3")
+    ])
+    harness.queue_drain_mode = :one_at_a_time
+
+    queued = false
+    harness.prompt_message(user_message("first")) do |event|
+      next if queued || event.type != :agent_start
+
+      queued = true
+      harness.next_turn_message(user_message("queued one"))
+      harness.next_turn_message(user_message("queued two"))
+    end
+
+    assert_equal 3, client.calls.size
+    assert_equal [
+      user_message("first"),
+      stored_assistant_message("first response", id: "assistant_1"),
+      user_message("queued one")
+    ], client.calls[1][:messages]
+    assert_equal [
+      user_message("first"),
+      stored_assistant_message("first response", id: "assistant_1"),
+      user_message("queued one"),
+      stored_assistant_message("second response", id: "assistant_2"),
+      user_message("queued two")
+    ], client.calls[2][:messages]
+  end
+
+  test "steer messages queued while busy are added before the next model request" do
+    tool_request = assistant_tool_message("missing", {}, id: "assistant_missing", tool_use_id: "toolu_1")
+    final_response = assistant_message("handled", id: "assistant_final")
+    harness, _session, client = new_harness([ tool_request, final_response ], harness_class: ToolHarness)
+
+    queued = false
+    harness.prompt_message(user_message("use a missing tool")) do |event|
+      next if queued || event.type != :message_end
+
+      queued = true
+      harness.steer_message(user_message("please be concise"))
+    end
+
+    assert_equal [
+      user_message("use a missing tool"),
+      stored_message(tool_request),
+      tool_result_message("toolu_1", "Unknown tool: missing"),
+      user_message("please be concise")
+    ], client.calls[1][:messages]
+  end
+
+  test "follow up messages queued while busy run before next turn messages" do
+    harness, _session, client = new_harness([
+      assistant_message("first response", id: "assistant_1"),
+      assistant_message("follow up response", id: "assistant_2"),
+      assistant_message("next turn response", id: "assistant_3")
+    ])
+
+    queued = false
+    harness.prompt_message(user_message("first")) do |event|
+      next if queued || event.type != :agent_start
+
+      queued = true
+      harness.follow_up_message(user_message("follow up"))
+      harness.next_turn_message(user_message("next turn"))
+    end
+
+    assert_equal 3, client.calls.size
+    assert_equal [
+      user_message("first"),
+      stored_assistant_message("first response", id: "assistant_1"),
+      user_message("follow up")
+    ], client.calls[1][:messages]
+    assert_equal [
+      user_message("first"),
+      stored_assistant_message("first response", id: "assistant_1"),
+      user_message("follow up"),
+      stored_assistant_message("follow up response", id: "assistant_2"),
+      user_message("next turn")
+    ], client.calls[2][:messages]
+  end
+
+  def tool_result_message(tool_use_id, content)
+    { role: "user", content: [ { type: "tool_result", tool_use_id: tool_use_id, content: content } ] }
+  end
+
+  test "preserves Anthropic tool_result blocks in the follow-up user message" do
+    tool_request = assistant_tool_message("missing", {}, id: "assistant_missing", tool_use_id: "toolu_1")
+    final_response = assistant_message("handled", id: "assistant_final")
+    harness, session, client = new_harness([ tool_request, final_response ], harness_class: ToolHarness)
+
+    harness.prompt_message(user_message("use a missing tool"))
+
+    expected_tool_result = tool_result_message("toolu_1", "Unknown tool: missing")
+    assert_equal [
+      user_message("use a missing tool"),
+      stored_message(tool_request),
+      expected_tool_result
+    ], client.calls[1][:messages]
+    assert_equal expected_tool_result, session.active_messages[2]
+  end
+
+  test "executes tools, records tool results, emits tool events, and continues until a final answer" do
+    add_request = assistant_tool_message("add", { left: 2, right: 3 }, id: "assistant_add", tool_use_id: "toolu_add")
+    unknown_request = assistant_tool_message("missing", {}, id: "assistant_missing", tool_use_id: "toolu_missing")
+    error_request = assistant_tool_message("explode", {}, id: "assistant_error", tool_use_id: "toolu_error")
+    final_response = assistant_message("all tools handled", id: "assistant_final")
+    harness, session, client = new_harness(
+      [ add_request, unknown_request, error_request, final_response ],
+      harness_class: ToolHarness
+    )
+    events = []
+
+    harness.prompt_message(user_message("use tools")) { |event| events << event }
+
+    assert_equal 4, client.calls.size
+    assert_equal [ AddTool.definition, ExplodingTool.definition ], client.calls.first[:options][:tools]
+    assert_equal [ user_message("use tools") ], client.calls[0][:messages]
+    assert_equal [ user_message("use tools"), stored_message(add_request), tool_result_message("toolu_add", 5) ],
+      client.calls[1][:messages]
+    assert_equal [
+      user_message("use tools"),
+      stored_message(add_request),
+      tool_result_message("toolu_add", 5),
+      stored_message(unknown_request),
+      tool_result_message("toolu_missing", "Unknown tool: missing")
+    ], client.calls[2][:messages]
+    assert_equal [
+      user_message("use tools"),
+      stored_message(add_request),
+      tool_result_message("toolu_add", 5),
+      stored_message(unknown_request),
+      tool_result_message("toolu_missing", "Unknown tool: missing"),
+      stored_message(error_request),
+      tool_result_message("toolu_error", "Error executing tool: boom")
+    ], client.calls[3][:messages]
+
+    tool_start_events = events.grep(LlmGateway::Agents::Event::ToolExecutionStart)
+    tool_end_events = events.grep(LlmGateway::Agents::Event::ToolExecutionEnd)
+    assert_equal [ "add", "missing", "explode" ], tool_start_events.map { |event| event.attributes.dig(:parameters, :name) }
+    assert_equal [ 5, "Unknown tool: missing", "Error executing tool: boom" ],
+      tool_end_events.map { |event| event.attributes.dig(:result, :content) }
+    assert_equal [
+      user_message("use tools"),
+      stored_message(add_request),
+      tool_result_message("toolu_add", 5),
+      stored_message(unknown_request),
+      tool_result_message("toolu_missing", "Unknown tool: missing"),
+      stored_message(error_request),
+      tool_result_message("toolu_error", "Error executing tool: boom"),
+      stored_message(final_response)
+    ], session.active_messages
+  end
+
+  test "tracks event parent relationships and returns events up to a requested event" do
+    _harness, session, = new_harness([])
+
+    session.push_message(user_message("one"))
+    second = session.push_message(assistant_message("two").to_h)
+    session.push_message(user_message("three"))
+
+    assert_nil session.events.first[:parent_id]
+    session.events.each_cons(2) do |parent, child|
+      assert_equal parent[:id], child[:parent_id]
+    end
+
+    second_index = session.events.index(second)
+    assert_equal session.events[0..second_index], session.events_until(second[:id])
+    assert_equal session.events.last[:id], session.last_message_id
+  end
+
+  test "raises when requested event does not exist" do
+    _harness, session, = new_harness([])
+
+    error = assert_raises(ArgumentError) { session.events_until("missing-event") }
+    assert_equal "Event not found in session: missing-event", error.message
+  end
+
+  test "returns active messages after compaction and builds model input with compaction message" do
+    harness, session, client = new_harness([
+      assistant_message("large response", total_tokens: LlmGateway::Agents::Harness::COMPACTION_TOKEN_THRESHOLD + 1),
+      assistant_message("summary of earlier conversation", id: "summary"),
+      assistant_message("after compaction", id: "after")
+    ])
+
+    harness.prompt_message(user_message("make this large"))
+    assert_equal "message", session.events.last[:type]
+
+    harness.prompt_message(user_message("new question"))
+
+    compaction_entry = session.events.find { |entry| entry[:type] == "compaction" }
+    assert_equal compacted_assistant_message("summary of earlier conversation", id: "summary"), compaction_entry[:data]
+    assert_equal [ user_message("new question"), stored_assistant_message("after compaction", id: "after") ], session.active_messages
+    assert_equal [
+      compacted_assistant_message("summary of earlier conversation", id: "summary"),
+      user_message("new question"),
+      stored_assistant_message("after compaction", id: "after")
+    ], harness.transcript
+
+    assert_equal [ user_message("make this large"), stored_assistant_message("large response", total_tokens: LlmGateway::Agents::Harness::COMPACTION_TOKEN_THRESHOLD + 1) ],
+      client.calls[1][:messages]
+    assert_equal "Summarize the conversation so far for future context.", client.calls[1][:options][:system]
+  end
+
+  test "compacts before next user message when last assistant message is older than one hour" do
+    harness, session, client = new_harness([
+      assistant_message("old response"),
+      assistant_message("summary after idle", id: "summary"),
+      assistant_message("after idle compaction", id: "after")
+    ])
+
+    harness.prompt_message(user_message("first question"))
+    session.events.last[:timestamp] = (Time.now - LlmGateway::Agents::Harness::COMPACTION_IDLE_THRESHOLD_SECONDS - 1).iso8601
+
+    harness.prompt_message(user_message("second question"))
+
+    compaction_entry = session.events.find { |entry| entry[:type] == "compaction" }
+    assert_equal compacted_assistant_message("summary after idle", id: "summary"), compaction_entry[:data]
+    assert_equal [ user_message("second question"), stored_assistant_message("after idle compaction", id: "after") ], session.active_messages
+    assert_equal [ user_message("first question"), stored_assistant_message("old response") ], client.calls[1][:messages]
+    assert_equal "Summarize the conversation so far for future context.", client.calls[1][:options][:system]
+  end
+
+  test "tracks total tokens from latest usage" do
+    _harness, session, = new_harness([])
+
+    assert_equal 0, session.total_tokens
+    session.push_message(assistant_message("small", total_tokens: 42).to_h)
+    session.push_message(user_message("no usage"))
+    assert_equal 42, session.total_tokens
+    session.push_message(assistant_message("larger", total_tokens: 123).to_h)
+    assert_equal 123, session.total_tokens
+  end
+end

--- a/test/unit/file_session_manager_test.rb
+++ b/test/unit/file_session_manager_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "json"
+require "tmpdir"
+require "llm_gateway/agents/file_session_manager"
+
+class FileSessionManagerTest < Test
+  def with_tmpdir
+    Dir.mktmpdir do |dir|
+      yield dir
+    end
+  end
+
+  def user_message(text)
+    { role: "user", content: [ { type: "text", text: text } ] }
+  end
+
+  test "creates a JSONL session file and appends events" do
+    with_tmpdir do |dir|
+      session = LlmGateway::Agents::FileSessionManager.new(
+        nil,
+        session_id: "session-1",
+        session_start: "20260521_120000",
+        session_dir: dir
+      )
+
+      session.push_message(user_message("hello"))
+
+      path = File.join(dir, "20260521_120000_session-1.jsonl")
+      assert_equal path, session.session_path
+      lines = File.readlines(path).map { |line| JSON.parse(line, symbolize_names: true) }
+
+      assert_equal [ "session", "message" ], lines.map { |event| event[:type] }
+      assert_equal "session-1", lines.first[:id]
+      assert_equal user_message("hello"), lines.last[:data]
+    end
+  end
+
+  test "loads an existing session and continues appending without persisting queued messages" do
+    with_tmpdir do |dir|
+      path = File.join(dir, "session.jsonl")
+      original = LlmGateway::Agents::FileSessionManager.new(
+        path,
+        session_id: "session-1",
+        session_start: "20260521_120000"
+      )
+      original.push_message(user_message("one"))
+
+      loaded = LlmGateway::Agents::FileSessionManager.new(path)
+      assert_equal "session-1", loaded.session_id
+      assert_equal [ user_message("one") ], loaded.active_messages
+
+      loaded.busy!
+      loaded.push_message_to_queue(user_message("queued"))
+      assert_equal 2, File.readlines(path).size
+
+      loaded.idle!
+      loaded.drain_message_queue(:next_turn, mode: :one_at_a_time)
+
+      reloaded = LlmGateway::Agents::FileSessionManager.new(path)
+      assert_equal [ user_message("one"), user_message("queued") ], reloaded.active_messages
+      assert_equal 3, File.readlines(path).size
+    end
+  end
+
+  test "raises a helpful error for invalid JSONL" do
+    with_tmpdir do |dir|
+      path = File.join(dir, "bad.jsonl")
+      File.write(path, "{bad json\n")
+
+      error = assert_raises(ArgumentError) do
+        LlmGateway::Agents::FileSessionManager.new(path).events
+      end
+
+      assert_match(/Invalid JSONL in #{Regexp.escape(path)} at line 1:/, error.message)
+    end
+  end
+end


### PR DESCRIPTION
# Goal
Add an agent harness that can manage session-backed agent state and coordinate prompt execution across different runtime contexts.

# Changes made to achieve the goal
Introduces the core harness and event abstractions for agent execution, including session-based state management and queue draining behavior. Also aligns class attribute behavior with Rails 8.1 expectations to avoid conflicts with Rails implementations.

> read the commit messages for more details