### PR TITLE
feat: create server proxy and corresponding client

### DIFF
--- a/lib/llm_gateway.rb
+++ b/lib/llm_gateway.rb
@@ -48,6 +48,9 @@ require_relative "llm_gateway/adapters/groq/chat_completions_adapter"
 
 # Load provider registry
 require_relative "llm_gateway/provider_registry"
+require_relative "llm_gateway/proxy/client"
+require_relative "llm_gateway/proxy/adapter"
+require_relative "llm_gateway/proxy/server"
 
 module LlmGateway
   class Error < StandardError; end
@@ -110,7 +113,7 @@ module LlmGateway
     entry = ProviderRegistry.resolve(provider_name)
 
     client = entry[:client].new(**config)
-    entry[:adapter].new(client)
+    entry[:adapter].new(client, provider_key: provider_name)
   end
 
   def self.configure(configs)
@@ -160,4 +163,8 @@ module LlmGateway
   ProviderRegistry.register("openai_codex",
     client: Clients::OpenAI,
     adapter: Adapters::OpenAICodex::ResponsesAdapter)
+
+  ProviderRegistry.register("proxy",
+    client: Proxy::Client,
+    adapter: Proxy::Adapter)
 end

--- a/lib/llm_gateway/adapters/adapter.rb
+++ b/lib/llm_gateway/adapters/adapter.rb
@@ -5,32 +5,38 @@ require_relative "structs"
 module LlmGateway
   module Adapters
     class Adapter
-      attr_reader :client
+      attr_reader :client, :provider_key
 
-      def initialize(client)
+      def initialize(client, provider_key: nil)
         @client = client
+        @provider_key = provider_key
       end
 
-      def stream(message, tools: nil, system: nil, **options, &block)
-        raise LlmGateway::Errors::MissingMapperForProvider, "No stream_mapper configured" unless stream_mapper
-
+      def raw_stream(message, tools: nil, system: nil, **options, &block)
         normalized_input = map_input({
           messages: sanitize_messages(normalize_messages(message), target_model: options[:model]),
           tools: tools,
           system: normalize_system(system)
         })
 
+        perform_stream(
+          normalized_input[:messages],
+          tools: normalized_input[:tools],
+          system: normalized_input[:system],
+          **map_options(options),
+          &block
+        )
+      end
+
+      def stream(message, tools: nil, system: nil, **options, &block)
+        raise LlmGateway::Errors::MissingMapperForProvider, "No stream_mapper configured" unless stream_mapper
+
         mapper = stream_mapper.new(
           provider: LlmGateway::Client.provider_id_from_client(client),
           api: api_name
         )
 
-        perform_stream(
-          normalized_input[:messages],
-          tools: normalized_input[:tools],
-          system: normalized_input[:system],
-          **map_options(options)
-        ) do |chunk|
+        raw_stream(message, tools: tools, system: system, **options) do |chunk|
           mapper.map(chunk, &block)
         end
 
@@ -88,6 +94,18 @@ module LlmGateway
       def perform_stream(messages, tools:, system:, **options, &block)
         client.stream(messages, tools: tools, system: system, **options, &block)
       end
+
+      public
+
+      def stream_api_name
+        api_name
+      end
+
+      def stream_mapper_class
+        stream_mapper
+      end
+
+      private
 
       def api_name
         self.class.name.split("::").last.gsub(/Adapter$/, "").downcase

--- a/lib/llm_gateway/proxy/adapter.rb
+++ b/lib/llm_gateway/proxy/adapter.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module LlmGateway
+  module Proxy
+    class Adapter
+      attr_reader :client
+
+      def initialize(client)
+        @client = client
+      end
+
+      def stream(message, tools: nil, system: nil, **options, &block)
+        target_adapter = LlmGateway.build_provider(client.target_config.merge(provider: client.target_provider))
+        mapper_class = target_adapter.stream_mapper_class
+        raise LlmGateway::Errors::MissingMapperForProvider, "No stream_mapper configured" unless mapper_class
+
+        mapper = mapper_class.new(
+          provider: LlmGateway::Client.provider_id_from_client(target_adapter.client),
+          api: target_adapter.stream_api_name
+        )
+
+        client.stream(normalize_messages(message), tools: tools, system: normalize_system(system), **options) do |chunk|
+          mapper.map(chunk, &block)
+        end
+
+        mapper.result
+      end
+
+      private
+
+      def normalize_system(system)
+        if system.nil?
+          []
+        elsif system.is_a?(String)
+          [ { role: "system", content: system } ]
+        elsif system.is_a?(Array)
+          system
+        else
+          raise ArgumentError, "System parameter must be a string or array, got #{system.class}"
+        end
+      end
+
+      def normalize_messages(message)
+        message.is_a?(String) ? [ { role: "user", content: message } ] : message
+      end
+    end
+  end
+end

--- a/lib/llm_gateway/proxy/client.rb
+++ b/lib/llm_gateway/proxy/client.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "json"
+require "net/http"
+require "uri"
+
+module LlmGateway
+  module Proxy
+    class Client
+      attr_reader :url, :target_provider, :target_config, :path
+
+      def initialize(url:, target_provider:, target_config: {}, api_key: nil, path: "/agent/llm_proxy", **_options)
+        @url = url.to_s.sub(%r{/+\z}, "")
+        @target_provider = target_provider.to_s
+        @target_config = (target_config || {}).transform_keys(&:to_sym)
+        @api_key = api_key
+        @path = path.to_s.start_with?("/") ? path.to_s : "/#{path}"
+      end
+
+      def stream(messages, tools: nil, system: nil, **options, &block)
+        uri = URI("#{url}#{path}")
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.scheme == "https"
+        http.read_timeout = 480
+        http.open_timeout = 10
+
+        request = Net::HTTP::Post.new(uri)
+        request["content-type"] = "application/json"
+        request["accept"] = "text/event-stream"
+        request["accept-encoding"] = "identity"
+        request["authorization"] = "Bearer #{@api_key}" if @api_key
+        request.body = {
+          provider: target_provider,
+          config: target_config,
+          messages: messages,
+          system: system,
+          tools: tools,
+          options: options
+        }.to_json
+
+        http.request(request) do |response|
+          unless response.code.to_i == 200
+            body = +""
+            response.read_body { |chunk| body << chunk }
+            raise Errors::APIStatusError.new("Proxy request failed with status #{response.code}: #{body}", nil)
+          end
+
+          parse_sse_stream(response, &block)
+        end
+      end
+
+      private
+
+      def parse_sse_stream(response)
+        buffer = +""
+        response.read_body do |chunk|
+          buffer << chunk
+          while (idx = buffer.index("\n\n"))
+            raw_event = buffer.slice!(0, idx + 2)
+            event_type = nil
+            data_lines = []
+
+            raw_event.each_line do |line|
+              line = line.chomp
+              event_type = line.sub(/^event:\s*/, "") if line.start_with?("event:")
+              data_lines << line.sub(/^data:\s*/, "") if line.start_with?("data:")
+            end
+
+            next if data_lines.empty?
+
+            data_str = data_lines.join("\n")
+            next if data_str == "[DONE]"
+
+            data = begin
+              JSON.parse(data_str).deep_symbolize_keys
+            rescue JSON::ParserError
+              { raw: data_str }
+            end
+            yield({ event: event_type, data: data })
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/llm_gateway/proxy/server.rb
+++ b/lib/llm_gateway/proxy/server.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "json"
+
+module LlmGateway
+  module Proxy
+    class Server
+      PATH = "/agent/llm_proxy"
+
+      def call(env)
+        return not_found unless env["REQUEST_METHOD"] == "POST" && env["PATH_INFO"] == PATH
+
+        request = JSON.parse(env["rack.input"].read).deep_symbolize_keys
+        options = request[:options] || {}
+        options = options.merge(model: request[:model]) if request.key?(:model)
+        adapter = build_adapter(request)
+
+        body = Enumerator.new do |yielder|
+          adapter.raw_stream(
+            request[:messages],
+            system: request[:system],
+            tools: request[:tools],
+            **options
+          ) do |chunk|
+            yielder << encode_sse(chunk)
+          end
+        end
+
+        [ 200, { "content-type" => "text/event-stream", "cache-control" => "no-cache" }, body ]
+      rescue KeyError, JSON::ParserError, ArgumentError => e
+        json_error(400, e.message)
+      rescue Errors::UnsupportedProvider => e
+        json_error(404, e.message)
+      rescue StandardError => e
+        json_error(500, e.message)
+      end
+
+      private
+
+      def build_adapter(request)
+        provider = request.fetch(:provider)
+        config = (request[:config] || {}).merge(provider: provider)
+
+        LlmGateway.build_provider(config)
+      end
+
+      def encode_sse(chunk)
+        event = chunk[:event]
+        data = chunk[:data]
+        out = +""
+        out << "event: #{event}\n" if event
+        JSON.generate(data).each_line { |line| out << "data: #{line.chomp}\n" }
+        out << "\n"
+      end
+
+      def json_error(status, message)
+        [ status, { "content-type" => "application/json" }, [ { error: message }.to_json ] ]
+      end
+
+      def not_found
+        [ 404, { "content-type" => "application/json" }, [ { error: "Not found" }.to_json ] ]
+      end
+    end
+  end
+end

--- a/test/fixtures/vcr_cassettes/integration/live/proxy_server_client_test_rb/test_proxy_server_client_streams_anthropic_apikey_messages_claude-sonnet-4-20250514.yml
+++ b/test/fixtures/vcr_cassettes/integration/live/proxy_server_client_test_rb/test_proxy_server_client_streams_anthropic_apikey_messages_claude-sonnet-4-20250514.yml
@@ -1,0 +1,118 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.anthropic.com/v1/messages
+    body:
+      encoding: UTF-8
+      string: '{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":[{"type":"text","text":"Reply
+        with exactly these two words: proxy ok"}]}],"temperature":0,"max_tokens":20,"stream":true}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.anthropic.com
+      Anthropic-Version:
+      - '2023-06-01'
+      Content-Type:
+      - application/json
+      X-Api-Key:
+      - "<BEARER_TOKEN>"
+      Anthropic-Beta:
+      - code-execution-2025-05-22,files-api-2025-04-14
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 06 Jun 2026 05:23:03 GMT
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache
+      Anthropic-Ratelimit-Input-Tokens-Limit:
+      - '800000'
+      Anthropic-Ratelimit-Input-Tokens-Remaining:
+      - '800000'
+      Anthropic-Ratelimit-Input-Tokens-Reset:
+      - '2026-06-06T05:23:03Z'
+      Anthropic-Ratelimit-Output-Tokens-Limit:
+      - '160000'
+      Anthropic-Ratelimit-Output-Tokens-Remaining:
+      - '160000'
+      Anthropic-Ratelimit-Output-Tokens-Reset:
+      - '2026-06-06T05:23:03Z'
+      Anthropic-Ratelimit-Requests-Limit:
+      - '2000'
+      Anthropic-Ratelimit-Requests-Remaining:
+      - '1999'
+      Anthropic-Ratelimit-Requests-Reset:
+      - '2026-06-06T05:23:03Z'
+      Anthropic-Ratelimit-Tokens-Limit:
+      - '960000'
+      Anthropic-Ratelimit-Tokens-Remaining:
+      - '960000'
+      Anthropic-Ratelimit-Tokens-Reset:
+      - '2026-06-06T05:23:03Z'
+      Request-Id:
+      - req_011CbmSsoCLGFKdQnU1hSXET
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Anthropic-Organization-Id:
+      - 0fcc9bdc-70ee-4701-a64f-cdc9e356dfa8
+      Traceresponse:
+      - 00-ef6d42139bcac2730e1301c724e38ffb-ca111c6b07267839-01
+      Server:
+      - cloudflare
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - _cfuvid=gybxQsgKr3itTvrlGnwr4xMT3wMZnYbPepWPSpB7NlA-1780723382.8908918-1.0.1.1-NJBZeI_eRRBrLYOMWDs0nRowaiaCbD1Hv8Xfj3hhTI8;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      X-Robots-Tag:
+      - none
+      Cf-Ray:
+      - a074fb970bb2a06b-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: |+
+        event: message_start
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_016bAFLfnCDE2edrjqZDmtu6","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":16,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"not_available"}}   }
+
+        event: content_block_start
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}          }
+
+        event: ping
+        data: {"type": "ping"}
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"proxy"}    }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" ok"}      }
+
+        event: content_block_stop
+        data: {"type":"content_block_stop","index":0}
+
+        event: message_delta
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":16,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":5}}
+
+        event: message_stop
+        data: {"type":"message_stop"  }
+
+  recorded_at: Sat, 06 Jun 2026 05:23:03 GMT
+recorded_with: VCR 6.4.0
+...

--- a/test/fixtures/vcr_cassettes/integration/live/proxy_server_client_test_rb/test_proxy_server_client_streams_groq_completions_openai/gpt-oss-120b.yml
+++ b/test/fixtures/vcr_cassettes/integration/live/proxy_server_client_test_rb/test_proxy_server_client_streams_groq_completions_openai/gpt-oss-120b.yml
@@ -1,0 +1,89 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.groq.com/openai/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"openai/gpt-oss-120b","messages":[{"role":"user","content":[{"type":"text","text":"Reply
+        with exactly these two words: proxy ok"}]}],"tools":null,"stream_options":{"include_usage":true},"max_completion_tokens":64,"temperature":0,"include_reasoning":false,"response_format":{"type":"text"},"stream":true}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.groq.com
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 06 Jun 2026 05:23:02 GMT
+      Content-Type:
+      - text/event-stream
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache
+      Server:
+      - cloudflare
+      Vary:
+      - Origin
+      X-Groq-Region:
+      - bom
+      X-Ratelimit-Limit-Requests:
+      - '500000'
+      X-Ratelimit-Limit-Tokens:
+      - '250000'
+      X-Ratelimit-Remaining-Requests:
+      - '499999'
+      X-Ratelimit-Remaining-Tokens:
+      - '249900'
+      X-Ratelimit-Reset-Requests:
+      - 172ms
+      X-Ratelimit-Reset-Tokens:
+      - 24ms
+      X-Request-Id:
+      - req_01ktdp4ydafakbgg3pzha59zhw
+      Via:
+      - 1.1 google
+      Set-Cookie:
+      - __cf_bm=Z3XLZENB4RXgQ6i.gxCYVII0KhHgCw6kM6..jAhOOC8-1780723382.6639702-1.0.1.1-uf4B4yShgx1T3VPEeWhlkiSWBxOaQxsWfjuihetdZZmxUTXm6k3NeOPibSLfTMK91NiXK8DLTCAOYdK3AewH7V0xb9nKFGq3i3c5MNz6L3onwqax.CD23FCvjwE2nklM;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=groq.com; Expires=Sat, 06
+        Jun 2026 05:53:02 GMT
+      Strict-Transport-Security:
+      - max-age=15552000
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - a074fb95ad9a806f-SIN
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: UTF-8
+      string: |+
+        data: {"id":"chatcmpl-6b887471-6b08-405b-a6f5-409ed3a31202","object":"chat.completion.chunk","created":1780723382,"model":"openai/gpt-oss-120b","system_fingerprint":"fp_8db49de948","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"x_groq":{"id":"req_01ktdp4ydafakbgg3pzha59zhw","seed":757115548}}
+
+        data: {"id":"chatcmpl-6b887471-6b08-405b-a6f5-409ed3a31202","object":"chat.completion.chunk","created":1780723382,"model":"openai/gpt-oss-120b","system_fingerprint":"fp_8db49de948","choices":[{"index":0,"delta":{"content":"proxy"},"logprobs":null,"finish_reason":null}],"x_groq":{"id":"req_01ktdp4ydafakbgg3pzha59zhw","seed":757115548}}
+
+        data: {"id":"chatcmpl-6b887471-6b08-405b-a6f5-409ed3a31202","object":"chat.completion.chunk","created":1780723382,"model":"openai/gpt-oss-120b","system_fingerprint":"fp_8db49de948","choices":[{"index":0,"delta":{"content":" ok"},"logprobs":null,"finish_reason":null}],"x_groq":{"id":"req_01ktdp4ydafakbgg3pzha59zhw","seed":757115548}}
+
+        data: {"id":"chatcmpl-6b887471-6b08-405b-a6f5-409ed3a31202","object":"chat.completion.chunk","created":1780723382,"model":"openai/gpt-oss-120b","system_fingerprint":"fp_8db49de948","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"x_groq":{"id":"req_01ktdp4ydafakbgg3pzha59zhw","usage":{"queue_time":0.052784113,"prompt_tokens":80,"prompt_time":0.003126097,"completion_tokens":22,"completion_time":0.041727502,"total_tokens":102,"total_time":0.044853599,"completion_tokens_details":{"reasoning_tokens":18}}},"usage":{"queue_time":0.052784113,"prompt_tokens":80,"prompt_time":0.003126097,"completion_tokens":22,"completion_time":0.041727502,"total_tokens":102,"total_time":0.044853599,"completion_tokens_details":{"reasoning_tokens":18}}}
+
+        data: {"id":"chatcmpl-6b887471-6b08-405b-a6f5-409ed3a31202","object":"chat.completion.chunk","created":1780723382,"model":"openai/gpt-oss-120b","system_fingerprint":"fp_8db49de948","choices":[],"usage":{"queue_time":0.052784113,"prompt_tokens":80,"prompt_time":0.003126097,"completion_tokens":22,"completion_time":0.041727502,"total_tokens":102,"total_time":0.044853599,"completion_tokens_details":{"reasoning_tokens":18}},"service_tier":"on_demand"}
+
+        data: [DONE]
+
+  recorded_at: Sat, 06 Jun 2026 05:23:02 GMT
+recorded_with: VCR 6.4.0
+...

--- a/test/fixtures/vcr_cassettes/integration/live/proxy_server_client_test_rb/test_proxy_server_client_streams_openai_apikey_completions_gpt-5_1.yml
+++ b/test/fixtures/vcr_cassettes/integration/live/proxy_server_client_test_rb/test_proxy_server_client_streams_openai_apikey_completions_gpt-5_1.yml
@@ -1,0 +1,97 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-5.1","messages":[{"role":"user","content":[{"type":"text","text":"Reply
+        with exactly these two words: proxy ok"}]}],"max_completion_tokens":20,"temperature":0,"stream_options":{"include_usage":true},"stream":true}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.openai.com
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 06 Jun 2026 05:23:05 GMT
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Content-Length:
+      - '1707'
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - a074fb9d2c247a82-SIN
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Access-Control-Expose-Headers:
+      - CF-Ray
+      - CF-Ray
+      - X-Request-ID
+      Openai-Organization:
+      - user-ayzusypxu6roh2akxcbajqo9
+      Openai-Processing-Ms:
+      - '329'
+      Openai-Project:
+      - proj_nmULvLHfn5yjMz2KqRbQcEQl
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '500'
+      X-Ratelimit-Limit-Tokens:
+      - '500000'
+      X-Ratelimit-Remaining-Requests:
+      - '499'
+      X-Ratelimit-Remaining-Tokens:
+      - '499987'
+      X-Ratelimit-Reset-Requests:
+      - 120ms
+      X-Ratelimit-Reset-Tokens:
+      - 1ms
+      X-Request-Id:
+      - req_6826ff9d8ed64a9ab30c36471ada6098
+      Set-Cookie:
+      - __cf_bm=OE2rDEITDIIjLz7xCCpabbxFTYFIUqdawVfP1EJqHss-1780723383.8689892-1.0.1.1-rh99NQxWtWi5OScx.PZKplZDMRDj_hRUcWWHwbw3N84DnljW04uRG7qGVOx.SJcelRmYgIV__m0IAYmNtEsJ5K6woP6pDPR7jgdAhHKBsN7_vQM5umzRzC46COaLG6Y3;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=api.openai.com; Expires=Sat,
+        06 Jun 2026 05:53:05 GMT
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: UTF-8
+      string: |+
+        data: {"id":"chatcmpl-DndmqzlLc8JhUua3fAPiv0XA6Joc8","object":"chat.completion.chunk","created":1780723384,"model":"gpt-5.1-2025-11-13","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"finish_reason":null}],"usage":null,"obfuscation":"rRvhq9O9"}
+
+        data: {"id":"chatcmpl-DndmqzlLc8JhUua3fAPiv0XA6Joc8","object":"chat.completion.chunk","created":1780723384,"model":"gpt-5.1-2025-11-13","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"proxy"},"finish_reason":null}],"usage":null,"obfuscation":"4rmTi"}
+
+        data: {"id":"chatcmpl-DndmqzlLc8JhUua3fAPiv0XA6Joc8","object":"chat.completion.chunk","created":1780723384,"model":"gpt-5.1-2025-11-13","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" ok"},"finish_reason":null}],"usage":null,"obfuscation":"REHkVkO"}
+
+        data: {"id":"chatcmpl-DndmqzlLc8JhUua3fAPiv0XA6Joc8","object":"chat.completion.chunk","created":1780723384,"model":"gpt-5.1-2025-11-13","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":null,"obfuscation":"QCZI"}
+
+        data: {"id":"chatcmpl-DndmqzlLc8JhUua3fAPiv0XA6Joc8","object":"chat.completion.chunk","created":1780723384,"model":"gpt-5.1-2025-11-13","service_tier":"default","system_fingerprint":null,"choices":[],"usage":{"prompt_tokens":15,"completion_tokens":11,"total_tokens":26,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"6MDvQA1Kb"}
+
+        data: [DONE]
+
+  recorded_at: Sat, 06 Jun 2026 05:23:05 GMT
+recorded_with: VCR 6.4.0
+...

--- a/test/fixtures/vcr_cassettes/integration/live/proxy_server_client_test_rb/test_proxy_server_client_streams_openai_apikey_responses_gpt-5_4.yml
+++ b/test/fixtures/vcr_cassettes/integration/live/proxy_server_client_test_rb/test_proxy_server_client_streams_openai_apikey_responses_gpt-5_4.yml
@@ -1,0 +1,113 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/responses
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-5.4","input":[{"role":"user","content":[{"type":"input_text","text":"Reply
+        with exactly these two words: proxy ok"}]}],"temperature":0,"max_output_tokens":20,"stream":true}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.openai.com
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 06 Jun 2026 05:23:06 GMT
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - a074fba84992820b-SIN
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Access-Control-Expose-Headers:
+      - CF-Ray
+      - CF-Ray
+      - X-Request-ID
+      Openai-Organization:
+      - user-ayzusypxu6roh2akxcbajqo9
+      Openai-Processing-Ms:
+      - '377'
+      Openai-Project:
+      - proj_nmULvLHfn5yjMz2KqRbQcEQl
+      Openai-Version:
+      - '2020-10-01'
+      X-Ratelimit-Limit-Requests:
+      - '500'
+      X-Ratelimit-Limit-Tokens:
+      - '500000'
+      X-Ratelimit-Remaining-Requests:
+      - '499'
+      X-Ratelimit-Remaining-Tokens:
+      - '499822'
+      X-Ratelimit-Reset-Requests:
+      - 120ms
+      X-Ratelimit-Reset-Tokens:
+      - 21ms
+      X-Request-Id:
+      - req_fa250c8fdaca41db9213a9f1acf0698f
+      Set-Cookie:
+      - __cf_bm=rOkJLoNk6hCECK9KbRMwUVG_k74XjUuwz.DJonL6ONs-1780723385.6479368-1.0.1.1-3IR6_TuCARM9n1eKJZQlFKUmoGPjQaAWbfIxTgki118ho9veZ5iHXhT5gQN4BneW08LV66tLXzpWMUKgRW6PC75BZqFDlsA4Rse6eQhfGKtI6FxrrAWydpyVe0qiaI14;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=api.openai.com; Expires=Sat,
+        06 Jun 2026 05:53:06 GMT
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: UTF-8
+      string: |+
+        event: response.created
+        data: {"type":"response.created","response":{"id":"resp_087d0d996888a5d5006a23aeba02e8819badb6e6c706ca306b","object":"response","created_at":1780723386,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":20,"max_tool_calls":null,"model":"gpt-5.4-2026-03-05","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":0.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+        event: response.in_progress
+        data: {"type":"response.in_progress","response":{"id":"resp_087d0d996888a5d5006a23aeba02e8819badb6e6c706ca306b","object":"response","created_at":1780723386,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":20,"max_tool_calls":null,"model":"gpt-5.4-2026-03-05","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":0.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+        event: response.output_item.added
+        data: {"type":"response.output_item.added","item":{"id":"msg_087d0d996888a5d5006a23aebaaaa8819b982d3d8bb5917ddb","type":"message","status":"in_progress","content":[],"phase":"final_answer","role":"assistant"},"output_index":0,"sequence_number":2}
+
+        event: response.content_part.added
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_087d0d996888a5d5006a23aebaaaa8819b982d3d8bb5917ddb","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"proxy","item_id":"msg_087d0d996888a5d5006a23aebaaaa8819b982d3d8bb5917ddb","logprobs":[],"obfuscation":"agHFEJOh9Df","output_index":0,"sequence_number":4}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ok","item_id":"msg_087d0d996888a5d5006a23aebaaaa8819b982d3d8bb5917ddb","logprobs":[],"obfuscation":"WrY6m0oTgySaW","output_index":0,"sequence_number":5}
+
+        event: response.output_text.done
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_087d0d996888a5d5006a23aebaaaa8819b982d3d8bb5917ddb","logprobs":[],"output_index":0,"sequence_number":6,"text":"proxy ok"}
+
+        event: response.content_part.done
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_087d0d996888a5d5006a23aebaaaa8819b982d3d8bb5917ddb","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"proxy ok"},"sequence_number":7}
+
+        event: response.output_item.done
+        data: {"type":"response.output_item.done","item":{"id":"msg_087d0d996888a5d5006a23aebaaaa8819b982d3d8bb5917ddb","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"proxy ok"}],"phase":"final_answer","role":"assistant"},"output_index":0,"sequence_number":8}
+
+        event: response.completed
+        data: {"type":"response.completed","response":{"id":"resp_087d0d996888a5d5006a23aeba02e8819badb6e6c706ca306b","object":"response","created_at":1780723386,"status":"completed","background":false,"completed_at":1780723386,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":20,"max_tool_calls":null,"model":"gpt-5.4-2026-03-05","moderation":null,"output":[{"id":"msg_087d0d996888a5d5006a23aebaaaa8819b982d3d8bb5917ddb","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"proxy ok"}],"phase":"final_answer","role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":0.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":15,"input_tokens_details":{"cached_tokens":0},"output_tokens":6,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":21},"user":null,"metadata":{}},"sequence_number":9}
+
+  recorded_at: Sat, 06 Jun 2026 05:23:07 GMT
+recorded_with: VCR 6.4.0
+...

--- a/test/integration/live/proxy_server_client_test.rb
+++ b/test/integration/live/proxy_server_client_test.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "../../utils/live_test_helper"
+require "socket"
+require "stringio"
+
+class ProxyServerClientTest < Test
+  include LiveTestHelper
+
+  PAIRS = [
+    { name: "openai_apikey_completions", provider: "openai_completions", model: "gpt-5.1" },
+    { name: "anthropic_apikey_messages", provider: "anthropic_messages", model: "claude-sonnet-4-20250514" },
+    { name: "openai_apikey_responses", provider: "openai_responses", model: "gpt-5.4" },
+    { name: "groq_completions", provider: "groq_completions", model: "openai/gpt-oss-120b", options: { reasoning: "none", include_reasoning: false, max_completion_tokens: 64 } }
+  ].freeze
+
+  def teardown
+    LlmGateway.reset_configuration!
+  end
+
+  def self.define_proxy_test_for(name:, provider:, model:, oauth: false, options: {})
+    test "proxy_server_client_streams_#{name}_#{model}" do
+      with_proxy_server(provider:, oauth:) do |url|
+        client = LlmGateway::Proxy::Client.new(
+          url: url,
+          target_provider: provider,
+          target_config: {}
+        )
+        adapter = LlmGateway::Proxy::Adapter.new(client)
+
+        events = []
+        stream_options = { max_completion_tokens: 20, temperature: 0 }.merge(options)
+
+        response = adapter.stream(
+          "Reply with exactly these two words: proxy ok",
+          model: model,
+          **stream_options
+        ) do |event|
+          events << event
+        end
+
+        assert_instance_of AssistantMessage, response
+        refute_empty response.provider
+        refute_empty response.api
+        refute_empty events
+
+        text = response.content.select { |block| block.type == "text" }.map(&:text).join(" ").downcase
+        assert_includes text, "proxy"
+        assert_includes text, "ok"
+
+        assert_stream_message_end_matches_response(
+          events.find { |event| event.respond_to?(:type) && event.type.to_sym == :message_end },
+          response
+        )
+      end
+    end
+  end
+
+  PAIRS.each { |pair| define_proxy_test_for(**pair) }
+
+  private
+
+  def with_proxy_server(provider:, oauth:)
+    cassette_name = vcr_cassette_name
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.addr[1]
+    proxy_app = LlmGateway::Proxy::Server.new
+
+    VCR.configure { |config| config.ignore_hosts "127.0.0.1" }
+
+    thread = Thread.new do
+      Thread.current.report_on_exception = false
+      socket = server.accept
+      raw_request = read_http_request(socket)
+
+      VCR.use_cassette(cassette_name, match_requests_on: %i[method uri json_body]) do
+        status, headers, body = proxy_app.call(rack_env_for(raw_request, provider: provider, oauth: oauth))
+        reason = RackReason.reason(status)
+        socket.write "HTTP/1.1 #{status} #{reason}\r\n"
+        headers.each { |key, value| socket.write "#{key}: #{value}\r\n" }
+        socket.write "connection: close\r\n\r\n"
+        body.each { |chunk| socket.write(chunk) }
+      end
+    rescue IOError
+      # Server was closed before a request arrived.
+    ensure
+      socket&.close
+    end
+
+    yield "http://127.0.0.1:#{port}"
+  ensure
+    server&.close
+    thread&.join(5)
+    VCR.configure { |config| config.unignore_hosts "127.0.0.1" }
+  end
+
+  def rack_env_for(request, provider:, oauth:)
+    body = JSON.parse(request.fetch(:body, "{}"))
+    body["config"] = server_side_config_for(provider, oauth: oauth).merge(body["config"] || {})
+
+    {
+      "REQUEST_METHOD" => request.fetch(:method),
+      "PATH_INFO" => request.fetch(:path),
+      "rack.input" => StringIO.new(JSON.generate(body))
+    }
+  end
+
+  def read_http_request(socket)
+    request_line = socket.gets&.chomp
+    method, path = request_line.to_s.split.first(2)
+    headers = {}
+
+    while (line = socket.gets)
+      line = line.chomp
+      break if line.empty?
+
+      key, value = line.split(":", 2)
+      headers[key.downcase] = value.to_s.strip if key
+    end
+
+    body = socket.read(headers.fetch("content-length", "0").to_i)
+    { method: method, path: path, body: body }
+  end
+
+  module RackReason
+    def self.reason(status)
+      { 200 => "OK", 400 => "Bad Request", 404 => "Not Found", 500 => "Internal Server Error" }.fetch(status, "OK")
+    end
+  end
+
+  def server_side_config_for(provider, oauth:)
+    cassette_exists = File.exist?(vcr_cassette_path(vcr_cassette_name))
+
+    if provider == "openai_codex"
+      return { "api_key" => "vcr-replay-token", "account_id" => "vcr-replay-account" } if cassette_exists
+
+      return {
+        "api_key" => oauth_access_token_for("openai"),
+        "account_id" => load_auth_credentials("openai")["account_id"]
+      }
+    end
+
+    if oauth == true && provider == "anthropic_messages"
+      return { "api_key" => "sk-ant-oat-vcr-replay-token" } if cassette_exists
+
+      return { "api_key" => oauth_access_token_for("anthropic") }
+    end
+
+    return { "api_key" => "vcr-replay-token" } if cassette_exists
+
+    case provider
+    when "openai_completions", "openai_responses"
+      { "api_key" => ENV.fetch("OPENAI_API_KEY") }
+    when "groq_completions"
+      { "api_key" => ENV.fetch("GROQ_API_KEY") }
+    when "anthropic_messages"
+      { "api_key" => ENV.fetch("ANTHROPIC_API_KEY") }
+    else
+      {}
+    end
+  end
+end


### PR DESCRIPTION
# Goal
Add a server proxy flow so clients can stream LLM responses without storing provider API keys on the client machine.

# Changes made to achieve the goal
Introduce the proxy server/client path needed to forward streaming responses quickly while keeping message construction on the client side and credential handling on the server side.

> read the commit messages for more details
