### PR TITLE
feat: when codex hits a rate limit pass all the information

### DIFF
--- a/README.md
+++ b/README.md
@@ -916,6 +916,21 @@ puts result.content.select { |b| b.type == "text" }.map(&:text).join
 
 If your app refreshes tokens in the background, rebuild the adapter (or recreate client state) with the newest `access_token` before subsequent calls.
 
+### Codex rate-limit reset metadata
+
+OpenAI Codex usage-limit responses include reset information on `LlmGateway::Errors::RateLimitError`:
+
+```ruby
+begin
+  adapter.stream("Hello from OAuth auth", model: "gpt-5.4")
+rescue LlmGateway::Errors::RateLimitError => e
+  puts e.message                 # "The usage limit has been reached"
+  puts e.reset_after_seconds     # primary reset window, when available
+  puts e.reset_at                # Time for the primary reset, when available
+  puts e.rate_limit_info.inspect # full parsed Codex headers/body metadata
+end
+```
+
 ### Token refresh responsibility
 
 #### Library’s role (llm_gateway)

--- a/lib/llm_gateway/clients/openai.rb
+++ b/lib/llm_gateway/clients/openai.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "time"
+
 require_relative "../base_client"
 
 module LlmGateway
@@ -179,6 +181,87 @@ module LlmGateway
         }
       end
 
+      def rate_limit_error_options(response, error)
+        info = rate_limit_info(response, error)
+        return {} if info.empty?
+
+        {
+          reset_at: info[:primary_reset_at] || info[:reset_at],
+          reset_after_seconds: info[:primary_reset_after_seconds] || info[:reset_after_seconds],
+          rate_limit_info: info
+        }
+      end
+
+      def rate_limit_info(response, error)
+        headers = response_headers(response)
+        codex_headers = headers.select { |key, _value| key.start_with?("x-codex-") }
+        info = {}
+
+        info[:provider] = "openai_codex" if codex_headers.any?
+        info[:error_type] = error["type"]
+        info[:plan_type] = headers["x-codex-plan-type"] || error["plan_type"]
+        info[:active_limit] = headers["x-codex-active-limit"]
+        info[:primary_used_percent] = integer_header(headers, "x-codex-primary-used-percent")
+        info[:secondary_used_percent] = integer_header(headers, "x-codex-secondary-used-percent")
+        info[:primary_window_minutes] = integer_header(headers, "x-codex-primary-window-minutes")
+        info[:secondary_window_minutes] = integer_header(headers, "x-codex-secondary-window-minutes")
+        info[:primary_over_secondary_limit_percent] = integer_header(headers, "x-codex-primary-over-secondary-limit-percent")
+        info[:primary_reset_after_seconds] = integer_header(headers, "x-codex-primary-reset-after-seconds")
+        info[:secondary_reset_after_seconds] = integer_header(headers, "x-codex-secondary-reset-after-seconds")
+        info[:primary_reset_at] = epoch_time(headers["x-codex-primary-reset-at"])
+        info[:secondary_reset_at] = epoch_time(headers["x-codex-secondary-reset-at"])
+        info[:credits_has_credits] = boolean_header(headers, "x-codex-credits-has-credits")
+        info[:credits_balance] = integer_header(headers, "x-codex-credits-balance")
+        info[:credits_unlimited] = boolean_header(headers, "x-codex-credits-unlimited")
+        info[:reset_after_seconds] = integer_value(error["resets_in_seconds"]) || retry_after_seconds(headers["retry-after"])
+        info[:reset_at] = epoch_time(error["resets_at"]) || retry_after_time(headers["retry-after"])
+
+        info.compact
+      end
+
+      def response_headers(response)
+        headers = {}
+        response.each_header { |key, value| headers[key.downcase] = value }
+        headers
+      end
+
+      def integer_header(headers, key)
+        integer_value(headers[key])
+      end
+
+      def integer_value(value)
+        return nil if value.nil?
+
+        Integer(value)
+      rescue ArgumentError, TypeError
+        nil
+      end
+
+      def boolean_header(headers, key)
+        case headers[key].to_s.downcase
+        when "true" then true
+        when "false" then false
+        end
+      end
+
+      def epoch_time(value)
+        integer = integer_value(value)
+        Time.at(integer) if integer
+      end
+
+      def retry_after_seconds(value)
+        integer_value(value)
+      end
+
+      def retry_after_time(value)
+        seconds = retry_after_seconds(value)
+        return Time.now + seconds if seconds
+
+        Time.httpdate(value)
+      rescue ArgumentError, TypeError
+        nil
+      end
+
       def handle_client_specific_errors(response, error)
         # OpenAI uses 'code' instead of 'type' for error codes
         error_code = error["code"]
@@ -190,7 +273,7 @@ module LlmGateway
 
         case response.code.to_i
         when 429
-          raise Errors::RateLimitError.new(error_message, error_code)
+          raise Errors::RateLimitError.new(error_message, error_code, **rate_limit_error_options(response, error))
         when 503
           raise Errors::OverloadError.new(error_message, error_code)
         end

--- a/lib/llm_gateway/errors.rb
+++ b/lib/llm_gateway/errors.rb
@@ -19,7 +19,16 @@ module LlmGateway
     class NotFoundError < ClientError; end
     class ConflictError < ClientError; end
     class UnprocessableEntityError < ClientError; end
-    class RateLimitError < ClientError; end
+    class RateLimitError < ClientError
+      attr_reader :reset_at, :reset_after_seconds, :rate_limit_info
+
+      def initialize(message = nil, code = nil, reset_at: nil, reset_after_seconds: nil, rate_limit_info: {})
+        @reset_at = reset_at
+        @reset_after_seconds = reset_after_seconds
+        @rate_limit_info = rate_limit_info
+        super(message, code)
+      end
+    end
     class InternalServerError < ClientError; end
     class APIStatusError < ClientError; end
     class APITimeoutError < ClientError; end

--- a/test/integration/clients/openai_test.rb
+++ b/test/integration/clients/openai_test.rb
@@ -182,4 +182,59 @@ class OpenaiClientTest < Test
 
     assert events.any? { |e| e[:event] == "response.completed" }
   end
+
+  test "stream_codex exposes rate limit reset details" do
+    stub_request(:post, "https://chatgpt.com/backend-api/codex/responses")
+      .to_return(
+        status: 429,
+        body: {
+          error: {
+            type: "usage_limit_reached",
+            message: "The usage limit has been reached",
+            plan_type: "plus",
+            resets_at: 1_782_234_727,
+            resets_in_seconds: 1_111
+          }
+        }.to_json,
+        headers: {
+          "Content-Type" => "application/json",
+          "x-codex-active-limit" => "premium",
+          "x-codex-plan-type" => "plus",
+          "x-codex-primary-used-percent" => "100",
+          "x-codex-secondary-used-percent" => "85",
+          "x-codex-primary-window-minutes" => "300",
+          "x-codex-secondary-window-minutes" => "10080",
+          "x-codex-primary-reset-after-seconds" => "1112",
+          "x-codex-secondary-reset-after-seconds" => "166201",
+          "x-codex-primary-reset-at" => "1782234728",
+          "x-codex-secondary-reset-at" => "1782399817",
+          "x-codex-credits-has-credits" => "False",
+          "x-codex-credits-balance" => "0",
+          "x-codex-credits-unlimited" => "False"
+        }
+      )
+
+    error = assert_raises(LlmGateway::Errors::RateLimitError) do
+      LlmGateway::Clients::OpenAI.new(api_key: "oauth-token").stream_codex([ { role: "user", content: "hello" } ])
+    end
+
+    assert_equal "The usage limit has been reached", error.message
+    assert_nil error.code
+    assert_equal Time.at(1_782_234_728), error.reset_at
+    assert_equal 1_112, error.reset_after_seconds
+    assert_equal "openai_codex", error.rate_limit_info[:provider]
+    assert_equal "usage_limit_reached", error.rate_limit_info[:error_type]
+    assert_equal "plus", error.rate_limit_info[:plan_type]
+    assert_equal "premium", error.rate_limit_info[:active_limit]
+    assert_equal 100, error.rate_limit_info[:primary_used_percent]
+    assert_equal 85, error.rate_limit_info[:secondary_used_percent]
+    assert_equal 300, error.rate_limit_info[:primary_window_minutes]
+    assert_equal 10_080, error.rate_limit_info[:secondary_window_minutes]
+    assert_equal Time.at(1_782_399_817), error.rate_limit_info[:secondary_reset_at]
+    assert_equal 1_111, error.rate_limit_info[:reset_after_seconds]
+    assert_equal Time.at(1_782_234_727), error.rate_limit_info[:reset_at]
+    assert_equal false, error.rate_limit_info[:credits_has_credits]
+    assert_equal 0, error.rate_limit_info[:credits_balance]
+    assert_equal false, error.rate_limit_info[:credits_unlimited]
+  end
 end


### PR DESCRIPTION
right now i am just passing everything we can consolidate that later as we see more examples but not adding any other oauth providers soon