### PR TITLE
fix: do not return empty assistant blocks

### DIFF
--- a/lib/llm_gateway/adapters/normalized_stream_accumulator.rb
+++ b/lib/llm_gateway/adapters/normalized_stream_accumulator.rb
@@ -330,7 +330,9 @@ module LlmGateway
       end
 
       def serialized_blocks
-        blocks.compact.map do |content_block|
+        blocks.compact.filter_map do |content_block|
+          next if blank_text_block?(content_block)
+
           if [ "tool_use", "server_tool_use" ].include?(content_block[:type])
             next content_block.merge(input: parse_tool_input(content_block[:input]).deep_symbolize_keys)
           end
@@ -346,6 +348,10 @@ module LlmGateway
 
           content_block
         end
+      end
+
+      def blank_text_block?(content_block)
+        content_block[:type] == "text" && content_block[:text].to_s.blank?
       end
 
       def parse_tool_input(input)

--- a/test/unit/normalized_stream_accumulator_partial_test.rb
+++ b/test/unit/normalized_stream_accumulator_partial_test.rb
@@ -81,6 +81,35 @@ class NormalizedStreamAccumulatorPartialTest < Test
     assert_equal({ query: "ruby" }, tool_end.tool_call.input)
   end
 
+  test "serialized content drops empty text blocks" do
+    accumulator = LlmGateway::Adapters::NormalizedStreamAccumulator.new(provider: "test-provider", api: "test-api")
+    events = []
+
+    [
+      { type: :message_start, delta: { id: "msg_1", model: "test-model", role: "assistant" } },
+      { type: :text_start, delta: "" },
+      { type: :text_end },
+      { type: :tool_start, id: "tool_1", name: "search" },
+      { type: :tool_delta, delta: '{"query":"ruby"}' },
+      { type: :tool_end },
+      { type: :text_start, delta: "kept" },
+      { type: :text_end },
+      { type: :message_delta, delta: { stop_reason: "tool_use" } },
+      { type: :message_end }
+    ].each do |patch|
+      accumulator.push(patch) { |event| events << event }
+    end
+
+    assert_equal(
+      [
+        { type: "tool_use", id: "tool_1", name: "search", input: { query: "ruby" } },
+        { type: "text", text: "kept" }
+      ],
+      events.last.message.content.map(&:to_h)
+    )
+    assert_equal events.last.message.content.map(&:to_h), accumulator.result[:content]
+  end
+
   test "accumulator preserves provider supplied timestamp" do
     accumulator = LlmGateway::Adapters::NormalizedStreamAccumulator.new(provider: "test-provider", api: "test-api")
     events = []


### PR DESCRIPTION
it is possible to end up with empty assistant blocks, i am not 100% sure how.

i saw it with tool use could be something between openai and us broke but i havent seen any serious issue with it in prod, except that i cant use that transcript with another provider like anthropic.

so this ensures they dont make it through