### PR TITLE
feat: pass session event to tool call

### DIFF
--- a/lib/llm_gateway/agents/harness.rb
+++ b/lib/llm_gateway/agents/harness.rb
@@ -80,13 +80,13 @@ module LlmGateway
           emit(Event::MessageUpdate.new(stream_event: event), &block)
         end
 
-        session_manager.push_message(assistant_message.to_h)
+        persisted_message = session_manager.push_message(assistant_message.to_h)
         emit(Event::MessageEnd.new(message: assistant_message), &block)
 
         tool_results = tool_requests(assistant_message).map do |message|
           parameters = message.to_h
           emit(Event::ToolExecutionStart.new(parameters: parameters), &block)
-          tool_result = find_and_execute_tool(message)
+          tool_result = find_and_execute_tool(message, session_event: persisted_message)
           emit(Event::ToolExecutionEnd.new(parameters: parameters, result: tool_result), &block)
           tool_result
         end

--- a/lib/llm_gateway/agents/harness.rb
+++ b/lib/llm_gateway/agents/harness.rb
@@ -83,10 +83,10 @@ module LlmGateway
         persisted_message = session_manager.push_message(assistant_message.to_h)
         emit(Event::MessageEnd.new(message: assistant_message), &block)
 
-        tool_results = tool_requests(assistant_message).map do |message|
-          parameters = message.to_h
+        tool_results = tool_requests(assistant_message).map do |tool_content_block|
+          parameters = tool_content_block.to_h
           emit(Event::ToolExecutionStart.new(parameters: parameters), &block)
-          tool_result = find_and_execute_tool(message, session_event: persisted_message)
+          tool_result = find_and_execute_tool(tool_content_block, session_event: persisted_message)
           emit(Event::ToolExecutionEnd.new(parameters: parameters, result: tool_result), &block)
           tool_result
         end

--- a/lib/llm_gateway/prompt.rb
+++ b/lib/llm_gateway/prompt.rb
@@ -63,9 +63,9 @@ module LlmGateway
 
     private
 
-    def find_and_execute_tool(tool_request, **kwargs)
-      tool_name = tool_request.name
-      tool_input = tool_request.input
+    def find_and_execute_tool(tool_content_block, **kwargs)
+      tool_name = tool_content_block.name
+      tool_input = tool_content_block.input
       tool_class = self.class.find_tool(tool_name)
 
       result = begin
@@ -79,7 +79,7 @@ module LlmGateway
       end
       ToolResult.new(
         type: "tool_result",
-        tool_use_id: tool_request.id,
+        tool_use_id: tool_content_block.id,
         content: result,
       )
     end

--- a/lib/llm_gateway/prompt.rb
+++ b/lib/llm_gateway/prompt.rb
@@ -63,14 +63,14 @@ module LlmGateway
 
     private
 
-    def find_and_execute_tool(tool_request)
+    def find_and_execute_tool(tool_request, **kwargs)
       tool_name = tool_request.name
       tool_input = tool_request.input
       tool_class = self.class.find_tool(tool_name)
 
       result = begin
         if tool_class
-          execute_tool(tool_class, tool_input)
+          execute_tool(tool_class, tool_input, **kwargs)
         else
           "Unknown tool: #{tool_name}"
         end
@@ -84,7 +84,7 @@ module LlmGateway
       )
     end
 
-    def execute_tool(tool_class, tool_input)
+    def execute_tool(tool_class, tool_input, **kwargs)
       tool_class.new.execute(tool_input)
     end
 

--- a/test/integration/harness_in_memory_session_test.rb
+++ b/test/integration/harness_in_memory_session_test.rb
@@ -34,6 +34,19 @@ class HarnessInMemorySessionIntegrationTest < Test
     TOOLS = [ AddTool, ExplodingTool ]
   end
 
+  class KwargRecordingHarness < ToolHarness
+    TOOLS = ToolHarness::TOOLS
+
+    attr_reader :execute_tool_kwargs
+
+    private
+
+    def execute_tool(tool_class, tool_input, **kwargs)
+      @execute_tool_kwargs = kwargs
+      super
+    end
+  end
+
   FakeInnerClient = Struct.new(:model_key)
 
   class FakeAdapter
@@ -522,6 +535,19 @@ class HarnessInMemorySessionIntegrationTest < Test
       expected_tool_result
     ], client.calls[1][:messages]
     assert_equal expected_tool_result, session.active_messages[2]
+  end
+
+  test "passes persisted assistant message session event when executing tools" do
+    tool_request = assistant_tool_message("add", { left: 2, right: 3 }, id: "assistant_add", tool_use_id: "toolu_add")
+    final_response = assistant_message("handled", id: "assistant_final")
+    harness, session = new_harness([ tool_request, final_response ], harness_class: KwargRecordingHarness)
+
+    harness.prompt_message(user_message("use tools"))
+
+    session_event = harness.execute_tool_kwargs[:session_event]
+    assert_equal session.events.find { |event| event.dig(:data, :id) == "assistant_add" }, session_event
+    assert_equal "message", session_event[:type]
+    assert_equal stored_message(tool_request), session_event[:data]
   end
 
   test "executes tools, records tool results, emits tool events, and continues until a final answer" do


### PR DESCRIPTION
There are many use cases for wanting access to the full message and session within the tool call this enables that as part fo the harness